### PR TITLE
Spelling, String and Error from templates to ast

### DIFF
--- a/accessspecifier_gen.go
+++ b/accessspecifier_gen.go
@@ -25,10 +25,9 @@ func (as AccessSpecifier) Spelling() string {
 		return "AccessSpecifier=Protected"
 	case AccessSpecifier_Private:
 		return "AccessSpecifier=Private"
-
 	}
 
-	return fmt.Sprintf("AccessSpecifier unkown %d", int(as))
+	return fmt.Sprintf("AccessSpecifier unkown %d", as)
 }
 
 func (as AccessSpecifier) String() string {

--- a/availabilitykind_gen.go
+++ b/availabilitykind_gen.go
@@ -29,10 +29,9 @@ func (ak AvailabilityKind) Spelling() string {
 		return "Availability=NotAvailable"
 	case Availability_NotAccessible:
 		return "Availability=NotAccessible"
-
 	}
 
-	return fmt.Sprintf("AvailabilityKind unkown %d", int(ak))
+	return fmt.Sprintf("AvailabilityKind unkown %d", ak)
 }
 
 func (ak AvailabilityKind) String() string {

--- a/callingconv_gen.go
+++ b/callingconv_gen.go
@@ -9,20 +9,21 @@ import "fmt"
 type CallingConv uint32
 
 const (
-	CallingConv_Default      CallingConv = C.CXCallingConv_Default
-	CallingConv_C                        = C.CXCallingConv_C
-	CallingConv_X86StdCall               = C.CXCallingConv_X86StdCall
-	CallingConv_X86FastCall              = C.CXCallingConv_X86FastCall
-	CallingConv_X86ThisCall              = C.CXCallingConv_X86ThisCall
-	CallingConv_X86Pascal                = C.CXCallingConv_X86Pascal
-	CallingConv_AAPCS                    = C.CXCallingConv_AAPCS
-	CallingConv_AAPCS_VFP                = C.CXCallingConv_AAPCS_VFP
-	CallingConv_PnaclCall                = C.CXCallingConv_PnaclCall
-	CallingConv_IntelOclBicc             = C.CXCallingConv_IntelOclBicc
-	CallingConv_X86_64Win64              = C.CXCallingConv_X86_64Win64
-	CallingConv_X86_64SysV               = C.CXCallingConv_X86_64SysV
-	CallingConv_Invalid                  = C.CXCallingConv_Invalid
-	CallingConv_Unexposed                = C.CXCallingConv_Unexposed
+	CallingConv_Default       CallingConv = C.CXCallingConv_Default
+	CallingConv_C                         = C.CXCallingConv_C
+	CallingConv_X86StdCall                = C.CXCallingConv_X86StdCall
+	CallingConv_X86FastCall               = C.CXCallingConv_X86FastCall
+	CallingConv_X86ThisCall               = C.CXCallingConv_X86ThisCall
+	CallingConv_X86Pascal                 = C.CXCallingConv_X86Pascal
+	CallingConv_AAPCS                     = C.CXCallingConv_AAPCS
+	CallingConv_AAPCS_VFP                 = C.CXCallingConv_AAPCS_VFP
+	CallingConv_PnaclCall                 = C.CXCallingConv_PnaclCall
+	CallingConv_IntelOclBicc              = C.CXCallingConv_IntelOclBicc
+	CallingConv_X86_64Win64               = C.CXCallingConv_X86_64Win64
+	CallingConv_X86_64SysV                = C.CXCallingConv_X86_64SysV
+	CallingConv_X86VectorCall             = C.CXCallingConv_X86VectorCall
+	CallingConv_Invalid                   = C.CXCallingConv_Invalid
+	CallingConv_Unexposed                 = C.CXCallingConv_Unexposed
 )
 
 func (cc CallingConv) Spelling() string {
@@ -51,14 +52,15 @@ func (cc CallingConv) Spelling() string {
 		return "CallingConv=X86_64Win64"
 	case CallingConv_X86_64SysV:
 		return "CallingConv=X86_64SysV"
+	case CallingConv_X86VectorCall:
+		return "CallingConv=X86VectorCall"
 	case CallingConv_Invalid:
 		return "CallingConv=Invalid"
 	case CallingConv_Unexposed:
 		return "CallingConv=Unexposed"
-
 	}
 
-	return fmt.Sprintf("CallingConv unkown %d", int(cc))
+	return fmt.Sprintf("CallingConv unkown %d", cc)
 }
 
 func (cc CallingConv) String() string {

--- a/childvisitresult_gen.go
+++ b/childvisitresult_gen.go
@@ -31,10 +31,9 @@ func (cvr ChildVisitResult) Spelling() string {
 		return "ChildVisit=Continue"
 	case ChildVisit_Recurse:
 		return "ChildVisit=Recurse"
-
 	}
 
-	return fmt.Sprintf("ChildVisitResult unkown %d", int(cvr))
+	return fmt.Sprintf("ChildVisitResult unkown %d", cvr)
 }
 
 func (cvr ChildVisitResult) String() string {

--- a/clang-c/CXCompilationDatabase.h
+++ b/clang-c/CXCompilationDatabase.h
@@ -14,8 +14,8 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#ifndef CLANG_CXCOMPILATIONDATABASE_H
-#define CLANG_CXCOMPILATIONDATABASE_H
+#ifndef LLVM_CLANG_C_CXCOMPILATIONDATABASE_H
+#define LLVM_CLANG_C_CXCOMPILATIONDATABASE_H
 
 #include "clang-c/Platform.h"
 #include "clang-c/CXString.h"

--- a/clang-c/CXString.h
+++ b/clang-c/CXString.h
@@ -13,8 +13,8 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#ifndef CLANG_CXSTRING_H
-#define CLANG_CXSTRING_H
+#ifndef LLVM_CLANG_C_CXSTRING_H
+#define LLVM_CLANG_C_CXSTRING_H
 
 #include "clang-c/Platform.h"
 
@@ -33,7 +33,7 @@ extern "C" {
  * \brief A character string.
  *
  * The \c CXString type is used to return strings from the interface when
- * the ownership of that string might different from one call to the next.
+ * the ownership of that string might differ from one call to the next.
  * Use \c clang_getCString() to retrieve the string data and, once finished
  * with the string data, call \c clang_disposeString() to free the string.
  */

--- a/clang-c/Index.h
+++ b/clang-c/Index.h
@@ -15,13 +15,15 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#ifndef CLANG_C_INDEX_H
-#define CLANG_C_INDEX_H
+#ifndef LLVM_CLANG_C_INDEX_H
+#define LLVM_CLANG_C_INDEX_H
 
 #include <time.h>
 
 #include "clang-c/Platform.h"
+#include "clang-c/CXErrorCode.h"
 #include "clang-c/CXString.h"
+#include "clang-c/BuildSystem.h"
 
 /**
  * \brief The version constants for the libclang API.
@@ -32,7 +34,7 @@
  * compatible, thus CINDEX_VERSION_MAJOR is expected to remain stable.
  */
 #define CINDEX_VERSION_MAJOR 0
-#define CINDEX_VERSION_MINOR 20
+#define CINDEX_VERSION_MINOR 29
 
 #define CINDEX_VERSION_ENCODE(major, minor) ( \
       ((major) * 10000)                       \
@@ -336,6 +338,12 @@ CINDEX_LINKAGE CXFile clang_getFile(CXTranslationUnit tu,
                                     const char *file_name);
 
 /**
+ * \brief Returns non-zero if the \c file1 and \c file2 point to the same file,
+ * or they are both NULL.
+ */
+CINDEX_LINKAGE int clang_File_isEqual(CXFile file1, CXFile file2);
+
+/**
  * @}
  */
 
@@ -599,6 +607,32 @@ CINDEX_LINKAGE CXSourceLocation clang_getRangeStart(CXSourceRange range);
  * source range.
  */
 CINDEX_LINKAGE CXSourceLocation clang_getRangeEnd(CXSourceRange range);
+
+/**
+ * \brief Identifies an array of ranges.
+ */
+typedef struct {
+  /** \brief The number of ranges in the \c ranges array. */
+  unsigned count;
+  /**
+   * \brief An array of \c CXSourceRanges.
+   */
+  CXSourceRange *ranges;
+} CXSourceRangeList;
+
+/**
+ * \brief Retrieve all ranges that were skipped by the preprocessor.
+ *
+ * The preprocessor will skip lines when they are surrounded by an
+ * if/ifdef/ifndef directive whose condition does not evaluate to true.
+ */
+CINDEX_LINKAGE CXSourceRangeList *clang_getSkippedRanges(CXTranslationUnit tu,
+                                                         CXFile file);
+
+/**
+ * \brief Destroy the given \c CXSourceRangeList.
+ */
+CINDEX_LINKAGE void clang_disposeSourceRangeList(CXSourceRangeList *ranges);
 
 /**
  * @}
@@ -1052,10 +1086,27 @@ CINDEX_LINKAGE CXTranslationUnit clang_createTranslationUnitFromSourceFile(
                                          struct CXUnsavedFile *unsaved_files);
 
 /**
- * \brief Create a translation unit from an AST file (-emit-ast).
+ * \brief Same as \c clang_createTranslationUnit2, but returns
+ * the \c CXTranslationUnit instead of an error code.  In case of an error this
+ * routine returns a \c NULL \c CXTranslationUnit, without further detailed
+ * error codes.
  */
-CINDEX_LINKAGE CXTranslationUnit clang_createTranslationUnit(CXIndex,
-                                             const char *ast_filename);
+CINDEX_LINKAGE CXTranslationUnit clang_createTranslationUnit(
+    CXIndex CIdx,
+    const char *ast_filename);
+
+/**
+ * \brief Create a translation unit from an AST file (\c -emit-ast).
+ *
+ * \param[out] out_TU A non-NULL pointer to store the created
+ * \c CXTranslationUnit.
+ *
+ * \returns Zero on success, otherwise returns an error code.
+ */
+CINDEX_LINKAGE enum CXErrorCode clang_createTranslationUnit2(
+    CXIndex CIdx,
+    const char *ast_filename,
+    CXTranslationUnit *out_TU);
 
 /**
  * \brief Flags that control the creation of translation units.
@@ -1169,7 +1220,22 @@ enum CXTranslationUnit_Flags {
  * set of optimizations enabled may change from one version to the next.
  */
 CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
-  
+
+/**
+ * \brief Same as \c clang_parseTranslationUnit2, but returns
+ * the \c CXTranslationUnit instead of an error code.  In case of an error this
+ * routine returns a \c NULL \c CXTranslationUnit, without further detailed
+ * error codes.
+ */
+CINDEX_LINKAGE CXTranslationUnit
+clang_parseTranslationUnit(CXIndex CIdx,
+                           const char *source_filename,
+                           const char *const *command_line_args,
+                           int num_command_line_args,
+                           struct CXUnsavedFile *unsaved_files,
+                           unsigned num_unsaved_files,
+                           unsigned options);
+
 /**
  * \brief Parse the given source file and the translation unit corresponding
  * to that file.
@@ -1184,7 +1250,7 @@ CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
  * associated.
  *
  * \param source_filename The name of the source file to load, or NULL if the
- * source file is included in \p command_line_args.
+ * source file is included in \c command_line_args.
  *
  * \param command_line_args The command-line arguments that would be
  * passed to the \c clang executable if it were being invoked out-of-process.
@@ -1193,7 +1259,7 @@ CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
  * '-emit-ast', '-fsyntax-only' (which is the default), and '-o \<output file>'.
  *
  * \param num_command_line_args The number of command-line arguments in
- * \p command_line_args.
+ * \c command_line_args.
  *
  * \param unsaved_files the files that have not yet been saved to disk
  * but may be required for parsing, including the contents of
@@ -1208,18 +1274,22 @@ CINDEX_LINKAGE unsigned clang_defaultEditingTranslationUnitOptions(void);
  * is managed but not its compilation. This should be a bitwise OR of the
  * CXTranslationUnit_XXX flags.
  *
- * \returns A new translation unit describing the parsed code and containing
- * any diagnostics produced by the compiler. If there is a failure from which
- * the compiler cannot recover, returns NULL.
+ * \param[out] out_TU A non-NULL pointer to store the created
+ * \c CXTranslationUnit, describing the parsed code and containing any
+ * diagnostics produced by the compiler.
+ *
+ * \returns Zero on success, otherwise returns an error code.
  */
-CINDEX_LINKAGE CXTranslationUnit clang_parseTranslationUnit(CXIndex CIdx,
-                                                    const char *source_filename,
-                                         const char * const *command_line_args,
-                                                      int num_command_line_args,
-                                            struct CXUnsavedFile *unsaved_files,
-                                                     unsigned num_unsaved_files,
-                                                            unsigned options);
-  
+CINDEX_LINKAGE enum CXErrorCode
+clang_parseTranslationUnit2(CXIndex CIdx,
+                            const char *source_filename,
+                            const char *const *command_line_args,
+                            int num_command_line_args,
+                            struct CXUnsavedFile *unsaved_files,
+                            unsigned num_unsaved_files,
+                            unsigned options,
+                            CXTranslationUnit *out_TU);
+
 /**
  * \brief Flags that control how translation units are saved.
  *
@@ -1371,10 +1441,11 @@ CINDEX_LINKAGE unsigned clang_defaultReparseOptions(CXTranslationUnit TU);
  * The function \c clang_defaultReparseOptions() produces a default set of
  * options recommended for most uses, based on the translation unit.
  *
- * \returns 0 if the sources could be reparsed. A non-zero value will be
+ * \returns 0 if the sources could be reparsed.  A non-zero error code will be
  * returned if reparsing was impossible, such that the translation unit is
- * invalid. In such cases, the only valid call for \p TU is 
- * \c clang_disposeTranslationUnit(TU).
+ * invalid. In such cases, the only valid call for \c TU is
+ * \c clang_disposeTranslationUnit(TU).  The error codes returned by this
+ * routine are described by the \c CXErrorCode enum.
  */
 CINDEX_LINKAGE int clang_reparseTranslationUnit(CXTranslationUnit TU,
                                                 unsigned num_unsaved_files,
@@ -1671,7 +1742,7 @@ enum CXCursorKind {
 
   /**
    * \brief An expression that refers to some value declaration, such
-   * as a function, varible, or enumerator.
+   * as a function, variable, or enumerator.
    */
   CXCursor_DeclRefExpr                   = 101,
 
@@ -1909,7 +1980,7 @@ enum CXCursorKind {
    */
   CXCursor_ObjCBoolLiteralExpr           = 145,
 
-  /** \brief Represents the "self" expression in a ObjC method.
+  /** \brief Represents the "self" expression in an Objective-C method.
    */
   CXCursor_ObjCSelfExpr                  = 146,
 
@@ -2057,7 +2128,7 @@ enum CXCursorKind {
    */
   CXCursor_MSAsmStmt                     = 229,
 
-  /** \brief The null satement ";": C99 6.8.3p3.
+  /** \brief The null statement ";": C99 6.8.3p3.
    *
    * This cursor kind is used to describe the null statement.
    */
@@ -2072,7 +2143,91 @@ enum CXCursorKind {
    */
   CXCursor_OMPParallelDirective          = 232,
 
-  CXCursor_LastStmt                      = CXCursor_OMPParallelDirective,
+  /** \brief OpenMP SIMD directive.
+   */
+  CXCursor_OMPSimdDirective              = 233,
+
+  /** \brief OpenMP for directive.
+   */
+  CXCursor_OMPForDirective               = 234,
+
+  /** \brief OpenMP sections directive.
+   */
+  CXCursor_OMPSectionsDirective          = 235,
+
+  /** \brief OpenMP section directive.
+   */
+  CXCursor_OMPSectionDirective           = 236,
+
+  /** \brief OpenMP single directive.
+   */
+  CXCursor_OMPSingleDirective            = 237,
+
+  /** \brief OpenMP parallel for directive.
+   */
+  CXCursor_OMPParallelForDirective       = 238,
+
+  /** \brief OpenMP parallel sections directive.
+   */
+  CXCursor_OMPParallelSectionsDirective  = 239,
+
+  /** \brief OpenMP task directive.
+   */
+  CXCursor_OMPTaskDirective              = 240,
+
+  /** \brief OpenMP master directive.
+   */
+  CXCursor_OMPMasterDirective            = 241,
+
+  /** \brief OpenMP critical directive.
+   */
+  CXCursor_OMPCriticalDirective          = 242,
+
+  /** \brief OpenMP taskyield directive.
+   */
+  CXCursor_OMPTaskyieldDirective         = 243,
+
+  /** \brief OpenMP barrier directive.
+   */
+  CXCursor_OMPBarrierDirective           = 244,
+
+  /** \brief OpenMP taskwait directive.
+   */
+  CXCursor_OMPTaskwaitDirective          = 245,
+
+  /** \brief OpenMP flush directive.
+   */
+  CXCursor_OMPFlushDirective             = 246,
+
+  /** \brief Windows Structured Exception Handling's leave statement.
+   */
+  CXCursor_SEHLeaveStmt                  = 247,
+
+  /** \brief OpenMP ordered directive.
+   */
+  CXCursor_OMPOrderedDirective           = 248,
+
+  /** \brief OpenMP atomic directive.
+   */
+  CXCursor_OMPAtomicDirective            = 249,
+
+  /** \brief OpenMP for SIMD directive.
+   */
+  CXCursor_OMPForSimdDirective           = 250,
+
+  /** \brief OpenMP parallel for SIMD directive.
+   */
+  CXCursor_OMPParallelForSimdDirective   = 251,
+
+  /** \brief OpenMP target directive.
+   */
+  CXCursor_OMPTargetDirective            = 252,
+
+  /** \brief OpenMP teams directive.
+   */
+  CXCursor_OMPTeamsDirective             = 253,
+
+  CXCursor_LastStmt                      = CXCursor_OMPTeamsDirective,
 
   /**
    * \brief Cursor that represents the translation unit itself.
@@ -2098,8 +2253,16 @@ enum CXCursorKind {
   CXCursor_AnnotateAttr                  = 406,
   CXCursor_AsmLabelAttr                  = 407,
   CXCursor_PackedAttr                    = 408,
-  CXCursor_LastAttr                      = CXCursor_PackedAttr,
-     
+  CXCursor_PureAttr                      = 409,
+  CXCursor_ConstAttr                     = 410,
+  CXCursor_NoDuplicateAttr               = 411,
+  CXCursor_CUDAConstantAttr              = 412,
+  CXCursor_CUDADeviceAttr                = 413,
+  CXCursor_CUDAGlobalAttr                = 414,
+  CXCursor_CUDAHostAttr                  = 415,
+  CXCursor_CUDASharedAttr                = 416,
+  CXCursor_LastAttr                      = CXCursor_CUDASharedAttr,
+
   /* Preprocessing */
   CXCursor_PreprocessingDirective        = 500,
   CXCursor_MacroDefinition               = 501,
@@ -2141,14 +2304,6 @@ typedef struct {
   int xdata;
   uintptr_t data[3];
 } CXCursor;
-
-/**
- * \brief A comment AST node.
- */
-typedef struct {
-  uintptr_t ASTNode;
-  CXTranslationUnit TranslationUnit;
-} CXComment;
 
 /**
  * \defgroup CINDEX_CURSOR_MANIP Cursor manipulations
@@ -2371,7 +2526,7 @@ clang_disposeCXPlatformAvailability(CXPlatformAvailability *availability);
 /**
  * \brief Describe the "language" of the entity referred to by a cursor.
  */
-CINDEX_LINKAGE enum CXLanguageKind {
+enum CXLanguageKind {
   CXLanguage_Invalid = 0,
   CXLanguage_C,
   CXLanguage_ObjC,
@@ -2437,10 +2592,10 @@ CINDEX_LINKAGE unsigned clang_CXCursorSet_insert(CXCursorSet cset,
  * void C::f() { }
  * \endcode
  *
- * In the out-of-line definition of \c C::f, the semantic parent is the 
+ * In the out-of-line definition of \c C::f, the semantic parent is
  * the class \c C, of which this function is a member. The lexical parent is
  * the place where the declaration actually occurs in the source code; in this
- * case, the definition occurs in the translation unit. In general, the 
+ * case, the definition occurs in the translation unit. In general, the
  * lexical parent for a given entity can change without affecting the semantics
  * of the program, and the lexical parent of different declarations of the
  * same entity may be different. Changing the semantic parent of a declaration,
@@ -2472,10 +2627,10 @@ CINDEX_LINKAGE CXCursor clang_getCursorSemanticParent(CXCursor cursor);
  * void C::f() { }
  * \endcode
  *
- * In the out-of-line definition of \c C::f, the semantic parent is the 
+ * In the out-of-line definition of \c C::f, the semantic parent is
  * the class \c C, of which this function is a member. The lexical parent is
  * the place where the declaration actually occurs in the source code; in this
- * case, the definition occurs in the translation unit. In general, the 
+ * case, the definition occurs in the translation unit. In general, the
  * lexical parent for a given entity can change without affecting the semantics
  * of the program, and the lexical parent of different declarations of the
  * same entity may be different. Changing the semantic parent of a declaration,
@@ -2600,7 +2755,7 @@ CINDEX_LINKAGE CXSourceLocation clang_getCursorLocation(CXCursor);
  *
  * The extent of a cursor starts with the file/line/column pointing at the
  * first character within the source construct that the cursor refers to and
- * ends with the last character withinin that source construct. For a
+ * ends with the last character within that source construct. For a
  * declaration, the extent covers the declaration itself. For a reference,
  * the extent covers the location of the reference (e.g., where the referenced
  * entity was actually used).
@@ -2622,7 +2777,7 @@ CINDEX_LINKAGE CXSourceRange clang_getCursorExtent(CXCursor);
  */
 enum CXTypeKind {
   /**
-   * \brief Reprents an invalid type (e.g., where no type is available).
+   * \brief Represents an invalid type (e.g., where no type is available).
    */
   CXType_Invalid = 0,
 
@@ -2700,6 +2855,7 @@ enum CXCallingConv {
   CXCallingConv_IntelOclBicc = 9,
   CXCallingConv_X86_64Win64 = 10,
   CXCallingConv_X86_64SysV = 11,
+  CXCallingConv_X86VectorCall = 12,
 
   CXCallingConv_Invalid = 100,
   CXCallingConv_Unexposed = 200
@@ -2790,6 +2946,124 @@ CINDEX_LINKAGE int clang_Cursor_getNumArguments(CXCursor C);
 CINDEX_LINKAGE CXCursor clang_Cursor_getArgument(CXCursor C, unsigned i);
 
 /**
+ * \brief Describes the kind of a template argument.
+ *
+ * See the definition of llvm::clang::TemplateArgument::ArgKind for full
+ * element descriptions.
+ */
+enum CXTemplateArgumentKind {
+  CXTemplateArgumentKind_Null,
+  CXTemplateArgumentKind_Type,
+  CXTemplateArgumentKind_Declaration,
+  CXTemplateArgumentKind_NullPtr,
+  CXTemplateArgumentKind_Integral,
+  CXTemplateArgumentKind_Template,
+  CXTemplateArgumentKind_TemplateExpansion,
+  CXTemplateArgumentKind_Expression,
+  CXTemplateArgumentKind_Pack,
+  /* Indicates an error case, preventing the kind from being deduced. */
+  CXTemplateArgumentKind_Invalid
+};
+
+/**
+ *\brief Returns the number of template args of a function decl representing a
+ * template specialization.
+ *
+ * If the argument cursor cannot be converted into a template function
+ * declaration, -1 is returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * The value 3 would be returned from this call.
+ */
+CINDEX_LINKAGE int clang_Cursor_getNumTemplateArguments(CXCursor C);
+
+/**
+ * \brief Retrieve the kind of the I'th template argument of the CXCursor C.
+ *
+ * If the argument CXCursor does not represent a FunctionDecl, an invalid
+ * template argument kind is returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
+ * respectively.
+ */
+CINDEX_LINKAGE enum CXTemplateArgumentKind clang_Cursor_getTemplateArgumentKind(
+    CXCursor C, unsigned I);
+
+/**
+ * \brief Retrieve a CXType representing the type of a TemplateArgument of a
+ *  function decl representing a template specialization.
+ *
+ * If the argument CXCursor does not represent a FunctionDecl whose I'th
+ * template argument has a kind of CXTemplateArgKind_Integral, an invalid type
+ * is returned.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * If called with I = 0, "float", will be returned.
+ * Invalid types will be returned for I == 1 or 2.
+ */
+CINDEX_LINKAGE CXType clang_Cursor_getTemplateArgumentType(CXCursor C,
+                                                           unsigned I);
+
+/**
+ * \brief Retrieve the value of an Integral TemplateArgument (of a function
+ *  decl representing a template specialization) as a signed long long.
+ *
+ * It is undefined to call this function on a CXCursor that does not represent a
+ * FunctionDecl or whose I'th template argument is not an integral value.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, -7, true>();
+ *
+ * If called with I = 1 or 2, -7 or true will be returned, respectively.
+ * For I == 0, this function's behavior is undefined.
+ */
+CINDEX_LINKAGE long long clang_Cursor_getTemplateArgumentValue(CXCursor C,
+                                                               unsigned I);
+
+/**
+ * \brief Retrieve the value of an Integral TemplateArgument (of a function
+ *  decl representing a template specialization) as an unsigned long long.
+ *
+ * It is undefined to call this function on a CXCursor that does not represent a
+ * FunctionDecl or whose I'th template argument is not an integral value.
+ *
+ * For example, for the following declaration and specialization:
+ *   template <typename T, int kInt, bool kBool>
+ *   void foo() { ... }
+ *
+ *   template <>
+ *   void foo<float, 2147483649, true>();
+ *
+ * If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
+ * For I == 0, this function's behavior is undefined.
+ */
+CINDEX_LINKAGE unsigned long long clang_Cursor_getTemplateArgumentUnsignedValue(
+    CXCursor C, unsigned I);
+
+/**
  * \brief Determine whether two CXTypes represent the same type.
  *
  * \returns non-zero if the CXTypes represent the same type and
@@ -2856,14 +3130,14 @@ CINDEX_LINKAGE CXString clang_getTypeKindSpelling(enum CXTypeKind K);
 CINDEX_LINKAGE enum CXCallingConv clang_getFunctionTypeCallingConv(CXType T);
 
 /**
- * \brief Retrieve the result type associated with a function type.
+ * \brief Retrieve the return type associated with a function type.
  *
  * If a non-function type is passed in, an invalid type is returned.
  */
 CINDEX_LINKAGE CXType clang_getResultType(CXType T);
 
 /**
- * \brief Retrieve the number of non-variadic arguments associated with a
+ * \brief Retrieve the number of non-variadic parameters associated with a
  * function type.
  *
  * If a non-function type is passed in, -1 is returned.
@@ -2871,7 +3145,7 @@ CINDEX_LINKAGE CXType clang_getResultType(CXType T);
 CINDEX_LINKAGE int clang_getNumArgTypes(CXType T);
 
 /**
- * \brief Retrieve the type of an argument of a function type.
+ * \brief Retrieve the type of a parameter of a function type.
  *
  * If a non-function type is passed in or the function does not have enough
  * parameters, an invalid type is returned.
@@ -2884,7 +3158,7 @@ CINDEX_LINKAGE CXType clang_getArgType(CXType T, unsigned i);
 CINDEX_LINKAGE unsigned clang_isFunctionTypeVariadic(CXType T);
 
 /**
- * \brief Retrieve the result type associated with a given cursor.
+ * \brief Retrieve the return type associated with a given cursor.
  *
  * This only returns a valid type if the cursor refers to a function or method.
  */
@@ -3014,6 +3288,24 @@ enum CXRefQualifierKind {
 };
 
 /**
+ * \brief Returns the number of template arguments for given class template
+ * specialization, or -1 if type \c T is not a class template specialization.
+ *
+ * Variadic argument packs count as only one argument, and can not be inspected
+ * further.
+ */
+CINDEX_LINKAGE int clang_Type_getNumTemplateArguments(CXType T);
+
+/**
+ * \brief Returns the type template argument of a template class specialization
+ * at given index.
+ *
+ * This function only returns template type arguments and does not handle
+ * template template arguments or variadic packs.
+ */
+CINDEX_LINKAGE CXType clang_Type_getTemplateArgumentAsType(CXType T, unsigned i);
+
+/**
  * \brief Retrieve the ref-qualifier kind of a function or method.
  *
  * The ref-qualifier is returned for C++ functions or methods. For other types
@@ -3052,6 +3344,29 @@ enum CX_CXXAccessSpecifier {
  * access specifier, the specifier itself is returned.
  */
 CINDEX_LINKAGE enum CX_CXXAccessSpecifier clang_getCXXAccessSpecifier(CXCursor);
+
+/**
+ * \brief Represents the storage classes as declared in the source. CX_SC_Invalid
+ * was added for the case that the passed cursor in not a declaration.
+ */
+enum CX_StorageClass {
+  CX_SC_Invalid,
+  CX_SC_None,
+  CX_SC_Extern,
+  CX_SC_Static,
+  CX_SC_PrivateExtern,
+  CX_SC_OpenCLWorkGroupLocal,
+  CX_SC_Auto,
+  CX_SC_Register
+};
+
+/**
+ * \brief Returns the storage class for a function or variable declaration.
+ *
+ * If the passed in Cursor is not a function or variable declaration,
+ * CX_SC_Invalid is returned else the storage class.
+ */
+CINDEX_LINKAGE enum CX_StorageClass clang_Cursor_getStorageClass(CXCursor);
 
 /**
  * \brief Determine the number of overloaded declarations referenced by a 
@@ -3276,8 +3591,8 @@ CINDEX_LINKAGE CXString clang_getCursorSpelling(CXCursor);
 /**
  * \brief Retrieve a range for a piece that forms the cursors spelling name.
  * Most of the times there is only one range for the complete spelling but for
- * objc methods and objc message expressions, there are multiple pieces for each
- * selector identifier.
+ * Objective-C methods and Objective-C message expressions, there are multiple
+ * pieces for each selector identifier.
  * 
  * \param pieceIndex the index of the spelling name piece. If this is greater
  * than the actual number of pieces, it will return a NULL (invalid) range.
@@ -3373,25 +3688,25 @@ CINDEX_LINKAGE CXCursor clang_getCanonicalCursor(CXCursor);
 
 
 /**
- * \brief If the cursor points to a selector identifier in a objc method or
- * message expression, this returns the selector index.
+ * \brief If the cursor points to a selector identifier in an Objective-C
+ * method or message expression, this returns the selector index.
  *
  * After getting a cursor with #clang_getCursor, this can be called to
  * determine if the location points to a selector identifier.
  *
- * \returns The selector index if the cursor is an objc method or message
+ * \returns The selector index if the cursor is an Objective-C method or message
  * expression and the cursor is pointing to a selector identifier, or -1
  * otherwise.
  */
 CINDEX_LINKAGE int clang_Cursor_getObjCSelectorIndex(CXCursor);
 
 /**
- * \brief Given a cursor pointing to a C++ method call or an ObjC message,
- * returns non-zero if the method/message is "dynamic", meaning:
+ * \brief Given a cursor pointing to a C++ method call or an Objective-C
+ * message, returns non-zero if the method/message is "dynamic", meaning:
  * 
  * For a C++ method: the call is virtual.
- * For an ObjC message: the receiver is an object instance, not 'super' or a
- * specific class.
+ * For an Objective-C message: the receiver is an object instance, not 'super'
+ * or a specific class.
  * 
  * If the method/message is "static" or the cursor does not point to a
  * method/message, it will return zero.
@@ -3399,8 +3714,8 @@ CINDEX_LINKAGE int clang_Cursor_getObjCSelectorIndex(CXCursor);
 CINDEX_LINKAGE int clang_Cursor_isDynamicCall(CXCursor C);
 
 /**
- * \brief Given a cursor pointing to an ObjC message, returns the CXType of the
- * receiver.
+ * \brief Given a cursor pointing to an Objective-C message, returns the CXType
+ * of the receiver.
  */
 CINDEX_LINKAGE CXType clang_Cursor_getReceiverType(CXCursor C);
 
@@ -3435,7 +3750,7 @@ CINDEX_LINKAGE unsigned clang_Cursor_getObjCPropertyAttributes(CXCursor C,
 
 /**
  * \brief 'Qualifiers' written next to the return and parameter types in
- * ObjC method declarations.
+ * Objective-C method declarations.
  */
 typedef enum {
   CXObjCDeclQualifier_None = 0x0,
@@ -3448,15 +3763,16 @@ typedef enum {
 } CXObjCDeclQualifierKind;
 
 /**
- * \brief Given a cursor that represents an ObjC method or parameter
- * declaration, return the associated ObjC qualifiers for the return type or the
- * parameter respectively. The bits are formed from CXObjCDeclQualifierKind.
+ * \brief Given a cursor that represents an Objective-C method or parameter
+ * declaration, return the associated Objective-C qualifiers for the return
+ * type or the parameter respectively. The bits are formed from
+ * CXObjCDeclQualifierKind.
  */
 CINDEX_LINKAGE unsigned clang_Cursor_getObjCDeclQualifiers(CXCursor C);
 
 /**
- * \brief Given a cursor that represents an ObjC method or property declaration,
- * return non-zero if the declaration was affected by "@optional".
+ * \brief Given a cursor that represents an Objective-C method or property
+ * declaration, return non-zero if the declaration was affected by "@optional".
  * Returns zero if the cursor is not such a declaration or it is "@required".
  */
 CINDEX_LINKAGE unsigned clang_Cursor_isObjCOptional(CXCursor C);
@@ -3487,11 +3803,18 @@ CINDEX_LINKAGE CXString clang_Cursor_getRawCommentText(CXCursor C);
 CINDEX_LINKAGE CXString clang_Cursor_getBriefCommentText(CXCursor C);
 
 /**
- * \brief Given a cursor that represents a documentable entity (e.g.,
- * declaration), return the associated parsed comment as a
- * \c CXComment_FullComment AST node.
+ * @}
  */
-CINDEX_LINKAGE CXComment clang_Cursor_getParsedComment(CXCursor C);
+
+/** \defgroup CINDEX_MANGLE Name Mangling API Functions
+ *
+ * @{
+ */
+
+/**
+ * \brief Retrieve the CXString representing the mangled name of the cursor.
+ */
+CINDEX_LINKAGE CXString clang_Cursor_getMangling(CXCursor);
 
 /**
  * @}
@@ -3511,6 +3834,12 @@ typedef void *CXModule;
  * \brief Given a CXCursor_ModuleImportDecl cursor, return the associated module.
  */
 CINDEX_LINKAGE CXModule clang_Cursor_getModule(CXCursor C);
+
+/**
+ * \brief Given a CXFile header file, return the module that contains it, if one
+ * exists.
+ */
+CINDEX_LINKAGE CXModule clang_getModuleForFile(CXTranslationUnit, CXFile);
 
 /**
  * \param Module a module object.
@@ -3545,6 +3874,13 @@ CINDEX_LINKAGE CXString clang_Module_getFullName(CXModule Module);
 /**
  * \param Module a module object.
  *
+ * \returns non-zero if the module is a system one.
+ */
+CINDEX_LINKAGE int clang_Module_isSystem(CXModule Module);
+
+/**
+ * \param Module a module object.
+ *
  * \returns the number of top level headers associated with this module.
  */
 CINDEX_LINKAGE unsigned clang_Module_getNumTopLevelHeaders(CXTranslationUnit,
@@ -3560,514 +3896,6 @@ CINDEX_LINKAGE unsigned clang_Module_getNumTopLevelHeaders(CXTranslationUnit,
 CINDEX_LINKAGE
 CXFile clang_Module_getTopLevelHeader(CXTranslationUnit,
                                       CXModule Module, unsigned Index);
-
-/**
- * @}
- */
-
-/**
- * \defgroup CINDEX_COMMENT Comment AST introspection
- *
- * The routines in this group provide access to information in the
- * documentation comment ASTs.
- *
- * @{
- */
-
-/**
- * \brief Describes the type of the comment AST node (\c CXComment).  A comment
- * node can be considered block content (e. g., paragraph), inline content
- * (plain text) or neither (the root AST node).
- */
-enum CXCommentKind {
-  /**
-   * \brief Null comment.  No AST node is constructed at the requested location
-   * because there is no text or a syntax error.
-   */
-  CXComment_Null = 0,
-
-  /**
-   * \brief Plain text.  Inline content.
-   */
-  CXComment_Text = 1,
-
-  /**
-   * \brief A command with word-like arguments that is considered inline content.
-   *
-   * For example: \\c command.
-   */
-  CXComment_InlineCommand = 2,
-
-  /**
-   * \brief HTML start tag with attributes (name-value pairs).  Considered
-   * inline content.
-   *
-   * For example:
-   * \verbatim
-   * <br> <br /> <a href="http://example.org/">
-   * \endverbatim
-   */
-  CXComment_HTMLStartTag = 3,
-
-  /**
-   * \brief HTML end tag.  Considered inline content.
-   *
-   * For example:
-   * \verbatim
-   * </a>
-   * \endverbatim
-   */
-  CXComment_HTMLEndTag = 4,
-
-  /**
-   * \brief A paragraph, contains inline comment.  The paragraph itself is
-   * block content.
-   */
-  CXComment_Paragraph = 5,
-
-  /**
-   * \brief A command that has zero or more word-like arguments (number of
-   * word-like arguments depends on command name) and a paragraph as an
-   * argument.  Block command is block content.
-   *
-   * Paragraph argument is also a child of the block command.
-   *
-   * For example: \\brief has 0 word-like arguments and a paragraph argument.
-   *
-   * AST nodes of special kinds that parser knows about (e. g., \\param
-   * command) have their own node kinds.
-   */
-  CXComment_BlockCommand = 6,
-
-  /**
-   * \brief A \\param or \\arg command that describes the function parameter
-   * (name, passing direction, description).
-   *
-   * For example: \\param [in] ParamName description.
-   */
-  CXComment_ParamCommand = 7,
-
-  /**
-   * \brief A \\tparam command that describes a template parameter (name and
-   * description).
-   *
-   * For example: \\tparam T description.
-   */
-  CXComment_TParamCommand = 8,
-
-  /**
-   * \brief A verbatim block command (e. g., preformatted code).  Verbatim
-   * block has an opening and a closing command and contains multiple lines of
-   * text (\c CXComment_VerbatimBlockLine child nodes).
-   *
-   * For example:
-   * \\verbatim
-   * aaa
-   * \\endverbatim
-   */
-  CXComment_VerbatimBlockCommand = 9,
-
-  /**
-   * \brief A line of text that is contained within a
-   * CXComment_VerbatimBlockCommand node.
-   */
-  CXComment_VerbatimBlockLine = 10,
-
-  /**
-   * \brief A verbatim line command.  Verbatim line has an opening command,
-   * a single line of text (up to the newline after the opening command) and
-   * has no closing command.
-   */
-  CXComment_VerbatimLine = 11,
-
-  /**
-   * \brief A full comment attached to a declaration, contains block content.
-   */
-  CXComment_FullComment = 12
-};
-
-/**
- * \brief The most appropriate rendering mode for an inline command, chosen on
- * command semantics in Doxygen.
- */
-enum CXCommentInlineCommandRenderKind {
-  /**
-   * \brief Command argument should be rendered in a normal font.
-   */
-  CXCommentInlineCommandRenderKind_Normal,
-
-  /**
-   * \brief Command argument should be rendered in a bold font.
-   */
-  CXCommentInlineCommandRenderKind_Bold,
-
-  /**
-   * \brief Command argument should be rendered in a monospaced font.
-   */
-  CXCommentInlineCommandRenderKind_Monospaced,
-
-  /**
-   * \brief Command argument should be rendered emphasized (typically italic
-   * font).
-   */
-  CXCommentInlineCommandRenderKind_Emphasized
-};
-
-/**
- * \brief Describes parameter passing direction for \\param or \\arg command.
- */
-enum CXCommentParamPassDirection {
-  /**
-   * \brief The parameter is an input parameter.
-   */
-  CXCommentParamPassDirection_In,
-
-  /**
-   * \brief The parameter is an output parameter.
-   */
-  CXCommentParamPassDirection_Out,
-
-  /**
-   * \brief The parameter is an input and output parameter.
-   */
-  CXCommentParamPassDirection_InOut
-};
-
-/**
- * \param Comment AST node of any kind.
- *
- * \returns the type of the AST node.
- */
-CINDEX_LINKAGE enum CXCommentKind clang_Comment_getKind(CXComment Comment);
-
-/**
- * \param Comment AST node of any kind.
- *
- * \returns number of children of the AST node.
- */
-CINDEX_LINKAGE unsigned clang_Comment_getNumChildren(CXComment Comment);
-
-/**
- * \param Comment AST node of any kind.
- *
- * \param ChildIdx child index (zero-based).
- *
- * \returns the specified child of the AST node.
- */
-CINDEX_LINKAGE
-CXComment clang_Comment_getChild(CXComment Comment, unsigned ChildIdx);
-
-/**
- * \brief A \c CXComment_Paragraph node is considered whitespace if it contains
- * only \c CXComment_Text nodes that are empty or whitespace.
- *
- * Other AST nodes (except \c CXComment_Paragraph and \c CXComment_Text) are
- * never considered whitespace.
- *
- * \returns non-zero if \c Comment is whitespace.
- */
-CINDEX_LINKAGE unsigned clang_Comment_isWhitespace(CXComment Comment);
-
-/**
- * \returns non-zero if \c Comment is inline content and has a newline
- * immediately following it in the comment text.  Newlines between paragraphs
- * do not count.
- */
-CINDEX_LINKAGE
-unsigned clang_InlineContentComment_hasTrailingNewline(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_Text AST node.
- *
- * \returns text contained in the AST node.
- */
-CINDEX_LINKAGE CXString clang_TextComment_getText(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns name of the inline command.
- */
-CINDEX_LINKAGE
-CXString clang_InlineCommandComment_getCommandName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns the most appropriate rendering mode, chosen on command
- * semantics in Doxygen.
- */
-CINDEX_LINKAGE enum CXCommentInlineCommandRenderKind
-clang_InlineCommandComment_getRenderKind(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \returns number of command arguments.
- */
-CINDEX_LINKAGE
-unsigned clang_InlineCommandComment_getNumArgs(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_InlineCommand AST node.
- *
- * \param ArgIdx argument index (zero-based).
- *
- * \returns text of the specified argument.
- */
-CINDEX_LINKAGE
-CXString clang_InlineCommandComment_getArgText(CXComment Comment,
-                                               unsigned ArgIdx);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
- * node.
- *
- * \returns HTML tag name.
- */
-CINDEX_LINKAGE CXString clang_HTMLTagComment_getTagName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \returns non-zero if tag is self-closing (for example, &lt;br /&gt;).
- */
-CINDEX_LINKAGE
-unsigned clang_HTMLStartTagComment_isSelfClosing(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \returns number of attributes (name-value pairs) attached to the start tag.
- */
-CINDEX_LINKAGE unsigned clang_HTMLStartTag_getNumAttrs(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \param AttrIdx attribute index (zero-based).
- *
- * \returns name of the specified attribute.
- */
-CINDEX_LINKAGE
-CXString clang_HTMLStartTag_getAttrName(CXComment Comment, unsigned AttrIdx);
-
-/**
- * \param Comment a \c CXComment_HTMLStartTag AST node.
- *
- * \param AttrIdx attribute index (zero-based).
- *
- * \returns value of the specified attribute.
- */
-CINDEX_LINKAGE
-CXString clang_HTMLStartTag_getAttrValue(CXComment Comment, unsigned AttrIdx);
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \returns name of the block command.
- */
-CINDEX_LINKAGE
-CXString clang_BlockCommandComment_getCommandName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \returns number of word-like arguments.
- */
-CINDEX_LINKAGE
-unsigned clang_BlockCommandComment_getNumArgs(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_BlockCommand AST node.
- *
- * \param ArgIdx argument index (zero-based).
- *
- * \returns text of the specified word-like argument.
- */
-CINDEX_LINKAGE
-CXString clang_BlockCommandComment_getArgText(CXComment Comment,
-                                              unsigned ArgIdx);
-
-/**
- * \param Comment a \c CXComment_BlockCommand or
- * \c CXComment_VerbatimBlockCommand AST node.
- *
- * \returns paragraph argument of the block command.
- */
-CINDEX_LINKAGE
-CXComment clang_BlockCommandComment_getParagraph(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns parameter name.
- */
-CINDEX_LINKAGE
-CXString clang_ParamCommandComment_getParamName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns non-zero if the parameter that this AST node represents was found
- * in the function prototype and \c clang_ParamCommandComment_getParamIndex
- * function will return a meaningful value.
- */
-CINDEX_LINKAGE
-unsigned clang_ParamCommandComment_isParamIndexValid(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns zero-based parameter index in function prototype.
- */
-CINDEX_LINKAGE
-unsigned clang_ParamCommandComment_getParamIndex(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns non-zero if parameter passing direction was specified explicitly in
- * the comment.
- */
-CINDEX_LINKAGE
-unsigned clang_ParamCommandComment_isDirectionExplicit(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_ParamCommand AST node.
- *
- * \returns parameter passing direction.
- */
-CINDEX_LINKAGE
-enum CXCommentParamPassDirection clang_ParamCommandComment_getDirection(
-                                                            CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns template parameter name.
- */
-CINDEX_LINKAGE
-CXString clang_TParamCommandComment_getParamName(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns non-zero if the parameter that this AST node represents was found
- * in the template parameter list and
- * \c clang_TParamCommandComment_getDepth and
- * \c clang_TParamCommandComment_getIndex functions will return a meaningful
- * value.
- */
-CINDEX_LINKAGE
-unsigned clang_TParamCommandComment_isParamPositionValid(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns zero-based nesting depth of this parameter in the template parameter list.
- *
- * For example,
- * \verbatim
- *     template<typename C, template<typename T> class TT>
- *     void test(TT<int> aaa);
- * \endverbatim
- * for C and TT nesting depth is 0,
- * for T nesting depth is 1.
- */
-CINDEX_LINKAGE
-unsigned clang_TParamCommandComment_getDepth(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_TParamCommand AST node.
- *
- * \returns zero-based parameter index in the template parameter list at a
- * given nesting depth.
- *
- * For example,
- * \verbatim
- *     template<typename C, template<typename T> class TT>
- *     void test(TT<int> aaa);
- * \endverbatim
- * for C and TT nesting depth is 0, so we can ask for index at depth 0:
- * at depth 0 C's index is 0, TT's index is 1.
- *
- * For T nesting depth is 1, so we can ask for index at depth 0 and 1:
- * at depth 0 T's index is 1 (same as TT's),
- * at depth 1 T's index is 0.
- */
-CINDEX_LINKAGE
-unsigned clang_TParamCommandComment_getIndex(CXComment Comment, unsigned Depth);
-
-/**
- * \param Comment a \c CXComment_VerbatimBlockLine AST node.
- *
- * \returns text contained in the AST node.
- */
-CINDEX_LINKAGE
-CXString clang_VerbatimBlockLineComment_getText(CXComment Comment);
-
-/**
- * \param Comment a \c CXComment_VerbatimLine AST node.
- *
- * \returns text contained in the AST node.
- */
-CINDEX_LINKAGE CXString clang_VerbatimLineComment_getText(CXComment Comment);
-
-/**
- * \brief Convert an HTML tag AST node to string.
- *
- * \param Comment a \c CXComment_HTMLStartTag or \c CXComment_HTMLEndTag AST
- * node.
- *
- * \returns string containing an HTML tag.
- */
-CINDEX_LINKAGE CXString clang_HTMLTagComment_getAsString(CXComment Comment);
-
-/**
- * \brief Convert a given full parsed comment to an HTML fragment.
- *
- * Specific details of HTML layout are subject to change.  Don't try to parse
- * this HTML back into an AST, use other APIs instead.
- *
- * Currently the following CSS classes are used:
- * \li "para-brief" for \\brief paragraph and equivalent commands;
- * \li "para-returns" for \\returns paragraph and equivalent commands;
- * \li "word-returns" for the "Returns" word in \\returns paragraph.
- *
- * Function argument documentation is rendered as a \<dl\> list with arguments
- * sorted in function prototype order.  CSS classes used:
- * \li "param-name-index-NUMBER" for parameter name (\<dt\>);
- * \li "param-descr-index-NUMBER" for parameter description (\<dd\>);
- * \li "param-name-index-invalid" and "param-descr-index-invalid" are used if
- * parameter index is invalid.
- *
- * Template parameter documentation is rendered as a \<dl\> list with
- * parameters sorted in template parameter list order.  CSS classes used:
- * \li "tparam-name-index-NUMBER" for parameter name (\<dt\>);
- * \li "tparam-descr-index-NUMBER" for parameter description (\<dd\>);
- * \li "tparam-name-index-other" and "tparam-descr-index-other" are used for
- * names inside template template parameters;
- * \li "tparam-name-index-invalid" and "tparam-descr-index-invalid" are used if
- * parameter position is invalid.
- *
- * \param Comment a \c CXComment_FullComment AST node.
- *
- * \returns string containing an HTML fragment.
- */
-CINDEX_LINKAGE CXString clang_FullComment_getAsHTML(CXComment Comment);
-
-/**
- * \brief Convert a given full parsed comment to an XML document.
- *
- * A Relax NG schema for the XML can be found in comment-xml-schema.rng file
- * inside clang source tree.
- *
- * \param Comment a \c CXComment_FullComment AST node.
- *
- * \returns string containing an XML document.
- */
-CINDEX_LINKAGE CXString clang_FullComment_getAsXML(CXComment Comment);
 
 /**
  * @}
@@ -4100,6 +3928,12 @@ CINDEX_LINKAGE unsigned clang_CXXMethod_isStatic(CXCursor C);
  * one of the base classes.
  */
 CINDEX_LINKAGE unsigned clang_CXXMethod_isVirtual(CXCursor C);
+
+/**
+ * \brief Determine if a C++ member function or member function template is
+ * declared 'const'.
+ */
+CINDEX_LINKAGE unsigned clang_CXXMethod_isConst(CXCursor C);
 
 /**
  * \brief Given a cursor that represents a template, determine
@@ -4191,7 +4025,7 @@ enum CXNameRefFlags {
    * Non-contiguous names occur in Objective-C when a selector with two or more
    * parameters is used, or in C++ when using an operator:
    * \code
-   * [object doSomething:here withValue:there]; // ObjC
+   * [object doSomething:here withValue:there]; // Objective-C
    * return some_vector[1]; // C++
    * \endcode
    */
@@ -5024,7 +4858,7 @@ CXDiagnostic clang_codeCompleteGetDiagnostic(CXCodeCompleteResults *Results,
                                              unsigned Index);
 
 /**
- * \brief Determines what compeltions are appropriate for the context
+ * \brief Determines what completions are appropriate for the context
  * the given code completion.
  * 
  * \param Results the code completion results to query
@@ -5474,7 +5308,7 @@ typedef struct {
   const CXIdxContainerInfo *declAsContainer;
   /**
    * \brief Whether the declaration exists in code or was created implicitly
-   * by the compiler, e.g. implicit objc methods for properties.
+   * by the compiler, e.g. implicit Objective-C methods for properties.
    */
   int isImplicit;
   const CXIdxAttrInfo *const *attributes;
@@ -5547,8 +5381,8 @@ typedef enum {
    */
   CXIdxEntityRef_Direct = 1,
   /**
-   * \brief An implicit reference, e.g. a reference of an ObjC method via the
-   * dot syntax.
+   * \brief An implicit reference, e.g. a reference of an Objective-C method
+   * via the dot syntax.
    */
   CXIdxEntityRef_Implicit = 2
 } CXIdxEntityRefKind;
@@ -5742,7 +5576,7 @@ typedef enum {
 
   /**
    * \brief Skip a function/method body that was already parsed during an
-   * indexing session assosiated with a \c CXIndexAction object.
+   * indexing session associated with a \c CXIndexAction object.
    * Bodies in system headers are always skipped.
    */
   CXIndexOpt_SkipParsedBodiesInSession = 0x10
@@ -5765,11 +5599,12 @@ typedef enum {
  * \param index_options A bitmask of options that affects how indexing is
  * performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
  *
- * \param out_TU [out] pointer to store a CXTranslationUnit that can be reused
- * after indexing is finished. Set to NULL if you do not require it.
+ * \param[out] out_TU pointer to store a \c CXTranslationUnit that can be
+ * reused after indexing is finished. Set to \c NULL if you do not require it.
  *
- * \returns If there is a failure from which the there is no recovery, returns
- * non-zero, otherwise returns 0.
+ * \returns 0 on success or if there were errors from which the compiler could
+ * recover.  If there is a failure from which the there is no recovery, returns
+ * a non-zero \c CXErrorCode.
  *
  * The rest of the parameters are the same as #clang_parseTranslationUnit.
  */
@@ -5837,6 +5672,9 @@ CXSourceLocation clang_indexLoc_getCXSourceLocation(CXIdxLoc loc);
 /**
  * @}
  */
+
+/* Include the comment API for compatibility. This will eventually go away. */
+#include "clang-c/Documentation.h"
 
 #ifdef __cplusplus
 }

--- a/clang-c/Platform.h
+++ b/clang-c/Platform.h
@@ -13,8 +13,8 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#ifndef CLANG_C_PLATFORM_H
-#define CLANG_C_PLATFORM_H
+#ifndef LLVM_CLANG_C_PLATFORM_H
+#define LLVM_CLANG_C_PLATFORM_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/cmd/go-clang-generate/generate/api.go
+++ b/cmd/go-clang-generate/generate/api.go
@@ -1,12 +1,12 @@
 package generate
 
 type API struct {
-	// ClangArguments hold command line arguments for Clang
+	// ClangArguments holds the command line arguments for Clang
 	ClangArguments []string
 
 	// PrepareFunctionName returns a prepared function name for further processing
 	PrepareFunctionName func(h *HeaderFile, f *Function) string
-	// PrepareFunction prepare a function for further processing
+	// PrepareFunction prepares a function for further processing
 	PrepareFunction func(f *Function)
 	// FilterFunction determines if a function is generateable
 	FilterFunction func(f *Function) bool
@@ -15,7 +15,7 @@ type API struct {
 	// FixedFunctionName returns an unempty string if a function needs to receive a specific name
 	FixedFunctionName func(f *Function) string
 
-	// PrepareStructMembers called before adding struct member getters
+	// PrepareStructMembers is called before adding struct member getters
 	PrepareStructMembers func(s *Struct)
 	// FilterStructMemberGetter determines if a getter should be generated for a member
 	FilterStructMemberGetter func(m *StructMember) bool

--- a/cmd/go-clang-generate/generate/ast.go
+++ b/cmd/go-clang-generate/generate/ast.go
@@ -1,8 +1,11 @@
 package generate
 
 import (
+	"bytes"
 	"go/ast"
+	"go/format"
 	"go/token"
+	"strings"
 )
 
 type ASTFunc struct {
@@ -31,6 +34,19 @@ func newASTFunc(f *Function) *ASTFunc {
 			Results: []ast.Expr{},
 		},
 	}
+}
+
+func generateFunctionString(fa *ASTFunc) string {
+	var b bytes.Buffer
+	err := format.Node(&b, token.NewFileSet(), []ast.Decl{fa.FuncDecl})
+	if err != nil {
+		panic(err)
+	}
+
+	fStr := b.String()
+	fStr = strings.Replace(fStr, "REMOVE()", "", -1)
+
+	return fStr
 }
 
 func (fa *ASTFunc) generate() {

--- a/cmd/go-clang-generate/generate/astutil.go
+++ b/cmd/go-clang-generate/generate/astutil.go
@@ -150,6 +150,27 @@ func doZero() *ast.BasicLit {
 	}
 }
 
+func doSwitchStmt(tag ast.Expr) *ast.SwitchStmt {
+	return &ast.SwitchStmt{
+		Tag:  tag,
+		Body: &ast.BlockStmt{},
+	}
+}
+
+func doCaseClause(c []ast.Expr, b []ast.Stmt) *ast.CaseClause {
+	return &ast.CaseClause{
+		List: c,
+		Body: b,
+	}
+}
+
+func doStringLit(value string) *ast.BasicLit {
+	return &ast.BasicLit{
+		Kind:  token.STRING,
+		Value: "\"" + value + "\"",
+	}
+}
+
 func getSliceType(typ Type) ast.Expr {
 	var sliceType ast.Expr
 

--- a/cmd/go-clang-generate/generate/function.go
+++ b/cmd/go-clang-generate/generate/function.go
@@ -1,10 +1,6 @@
 package generate
 
 import (
-	"bytes"
-	"go/ast"
-	"go/format"
-	"go/token"
 	"strings"
 
 	"github.com/sbinet/go-clang"
@@ -122,21 +118,12 @@ func (f *Function) generate() string {
 	fa := newASTFunc(f)
 	fa.generate()
 
-	var b bytes.Buffer
-	err := format.Node(&b, token.NewFileSet(), []ast.Decl{fa.FuncDecl})
-	if err != nil {
-		panic(err)
-	}
-
-	sss := b.String()
-
-	// TODO hack to make new lines... https://github.com/zimmski/go-clang-phoenix/issues/53
-	sss = strings.Replace(sss, "REMOVE()", "", -1)
+	fStr := generateFunctionString(fa)
 
 	// TODO find out how to position the comment correctly and do this using the AST https://github.com/zimmski/go-clang-phoenix/issues/54
 	if f.Comment != "" {
-		sss = f.Comment + "\n" + sss
+		fStr = f.Comment + "\n" + fStr
 	}
 
-	return sss
+	return fStr
 }

--- a/codecomplete_flags_gen.go
+++ b/codecomplete_flags_gen.go
@@ -31,10 +31,9 @@ func (ccf CodeComplete_Flags) Spelling() string {
 		return "CodeComplete=IncludeCodePatterns"
 	case CodeComplete_IncludeBriefComments:
 		return "CodeComplete=IncludeBriefComments"
-
 	}
 
-	return fmt.Sprintf("CodeComplete_Flags unkown %d", int(ccf))
+	return fmt.Sprintf("CodeComplete_Flags unkown %d", ccf)
 }
 
 func (ccf CodeComplete_Flags) String() string {

--- a/codecompleteresults_gen.go
+++ b/codecompleteresults_gen.go
@@ -43,7 +43,7 @@ func (ccr *CodeCompleteResults) Diagnostic(index uint16) Diagnostic {
 }
 
 /*
-	Determines what compeltions are appropriate for the context
+	Determines what completions are appropriate for the context
 	the given code completion.
 
 	Parameter Results the code completion results to query

--- a/comment_gen.go
+++ b/comment_gen.go
@@ -1,10 +1,10 @@
 package phoenix
 
-// #include "./clang-c/Index.h"
+// #include "./clang-c/Documentation.h"
 // #include "go-clang.h"
 import "C"
 
-// A comment AST node.
+// A parsed comment.
 type Comment struct {
 	c C.CXComment
 }

--- a/commentinlinecommandrenderkind_gen.go
+++ b/commentinlinecommandrenderkind_gen.go
@@ -1,6 +1,6 @@
 package phoenix
 
-// #include "./clang-c/Index.h"
+// #include "./clang-c/Documentation.h"
 // #include "go-clang.h"
 import "C"
 import "fmt"
@@ -29,10 +29,9 @@ func (cicrk CommentInlineCommandRenderKind) Spelling() string {
 		return "CommentInlineCommandRenderKind=Monospaced"
 	case CommentInlineCommandRenderKind_Emphasized:
 		return "CommentInlineCommandRenderKind=Emphasized"
-
 	}
 
-	return fmt.Sprintf("CommentInlineCommandRenderKind unkown %d", int(cicrk))
+	return fmt.Sprintf("CommentInlineCommandRenderKind unkown %d", cicrk)
 }
 
 func (cicrk CommentInlineCommandRenderKind) String() string {

--- a/commentkind_gen.go
+++ b/commentkind_gen.go
@@ -1,6 +1,6 @@
 package phoenix
 
-// #include "./clang-c/Index.h"
+// #include "./clang-c/Documentation.h"
 // #include "go-clang.h"
 import "C"
 import "fmt"
@@ -114,10 +114,9 @@ func (ck CommentKind) Spelling() string {
 		return "Comment=VerbatimLine"
 	case Comment_FullComment:
 		return "Comment=FullComment"
-
 	}
 
-	return fmt.Sprintf("CommentKind unkown %d", int(ck))
+	return fmt.Sprintf("CommentKind unkown %d", ck)
 }
 
 func (ck CommentKind) String() string {

--- a/commentparampassdirection_gen.go
+++ b/commentparampassdirection_gen.go
@@ -1,6 +1,6 @@
 package phoenix
 
-// #include "./clang-c/Index.h"
+// #include "./clang-c/Documentation.h"
 // #include "go-clang.h"
 import "C"
 import "fmt"
@@ -25,10 +25,9 @@ func (cppd CommentParamPassDirection) Spelling() string {
 		return "CommentParamPassDirection=Out"
 	case CommentParamPassDirection_InOut:
 		return "CommentParamPassDirection=InOut"
-
 	}
 
-	return fmt.Sprintf("CommentParamPassDirection unkown %d", int(cppd))
+	return fmt.Sprintf("CommentParamPassDirection unkown %d", cppd)
 }
 
 func (cppd CommentParamPassDirection) String() string {

--- a/compilationdatabase_error_gen.go
+++ b/compilationdatabase_error_gen.go
@@ -19,10 +19,9 @@ func (cde CompilationDatabase_Error) Spelling() string {
 		return "CompilationDatabase=NoError"
 	case CompilationDatabase_CanNotLoadDatabase:
 		return "CompilationDatabase=CanNotLoadDatabase"
-
 	}
 
-	return fmt.Sprintf("CompilationDatabase_Error unkown %d", int(cde))
+	return fmt.Sprintf("CompilationDatabase_Error unkown %d", cde)
 }
 
 func (cde CompilationDatabase_Error) String() string {

--- a/completionchunkkind_gen.go
+++ b/completionchunkkind_gen.go
@@ -191,10 +191,9 @@ func (cck CompletionChunkKind) Spelling() string {
 		return "CompletionChunk=HorizontalSpace"
 	case CompletionChunk_VerticalSpace:
 		return "CompletionChunk=VerticalSpace"
-
 	}
 
-	return fmt.Sprintf("CompletionChunkKind unkown %d", int(cck))
+	return fmt.Sprintf("CompletionChunkKind unkown %d", cck)
 }
 
 func (cck CompletionChunkKind) String() string {

--- a/completioncontext_gen.go
+++ b/completioncontext_gen.go
@@ -114,10 +114,9 @@ func (cc CompletionContext) Spelling() string {
 		return "CompletionContext=NaturalLanguage"
 	case CompletionContext_Unknown:
 		return "CompletionContext=Unknown"
-
 	}
 
-	return fmt.Sprintf("CompletionContext unkown %d", int(cc))
+	return fmt.Sprintf("CompletionContext unkown %d", cc)
 }
 
 func (cc CompletionContext) String() string {

--- a/cursor_gen.go
+++ b/cursor_gen.go
@@ -103,7 +103,7 @@ func (c Cursor) TranslationUnit() TranslationUnit {
 	void C::f() { }
 	\endcode
 
-	In the out-of-line definition of C::f, the semantic parent is the
+	In the out-of-line definition of C::f, the semantic parent is
 	the class C, of which this function is a member. The lexical parent is
 	the place where the declaration actually occurs in the source code; in this
 	case, the definition occurs in the translation unit. In general, the
@@ -140,7 +140,7 @@ func (c Cursor) SemanticParent() Cursor {
 	void C::f() { }
 	\endcode
 
-	In the out-of-line definition of C::f, the semantic parent is the
+	In the out-of-line definition of C::f, the semantic parent is
 	the class C, of which this function is a member. The lexical parent is
 	the place where the declaration actually occurs in the source code; in this
 	case, the definition occurs in the translation unit. In general, the
@@ -258,7 +258,7 @@ func (c Cursor) Location() SourceLocation {
 
 	The extent of a cursor starts with the file/line/column pointing at the
 	first character within the source construct that the cursor refers to and
-	ends with the last character withinin that source construct. For a
+	ends with the last character within that source construct. For a
 	declaration, the extent covers the declaration itself. For a reference,
 	the extent covers the location of the reference (e.g., where the referenced
 	entity was actually used).
@@ -347,6 +347,110 @@ func (c Cursor) Argument(i uint16) Cursor {
 	return Cursor{C.clang_Cursor_getArgument(c.c, C.uint(i))}
 }
 
+/*
+	Returns the number of template args of a function decl representing a
+	template specialization.
+
+	If the argument cursor cannot be converted into a template function
+	declaration, -1 is returned.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, -7, true>();
+
+	The value 3 would be returned from this call.
+*/
+func (c Cursor) NumTemplateArguments() int16 {
+	return int16(C.clang_Cursor_getNumTemplateArguments(c.c))
+}
+
+/*
+	Retrieve the kind of the I'th template argument of the CXCursor C.
+
+	If the argument CXCursor does not represent a FunctionDecl, an invalid
+	template argument kind is returned.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, -7, true>();
+
+	For I = 0, 1, and 2, Type, Integral, and Integral will be returned,
+	respectively.
+*/
+func (c Cursor) TemplateArgumentKind(i uint16) TemplateArgumentKind {
+	return TemplateArgumentKind(C.clang_Cursor_getTemplateArgumentKind(c.c, C.uint(i)))
+}
+
+/*
+	Retrieve a CXType representing the type of a TemplateArgument of a
+	function decl representing a template specialization.
+
+	If the argument CXCursor does not represent a FunctionDecl whose I'th
+	template argument has a kind of CXTemplateArgKind_Integral, an invalid type
+	is returned.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, -7, true>();
+
+	If called with I = 0, "float", will be returned.
+	Invalid types will be returned for I == 1 or 2.
+*/
+func (c Cursor) TemplateArgumentType(i uint16) Type {
+	return Type{C.clang_Cursor_getTemplateArgumentType(c.c, C.uint(i))}
+}
+
+/*
+	Retrieve the value of an Integral TemplateArgument (of a function
+	decl representing a template specialization) as a signed long long.
+
+	It is undefined to call this function on a CXCursor that does not represent a
+	FunctionDecl or whose I'th template argument is not an integral value.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, -7, true>();
+
+	If called with I = 1 or 2, -7 or true will be returned, respectively.
+	For I == 0, this function's behavior is undefined.
+*/
+func (c Cursor) TemplateArgumentValue(i uint16) int64 {
+	return int64(C.clang_Cursor_getTemplateArgumentValue(c.c, C.uint(i)))
+}
+
+/*
+	Retrieve the value of an Integral TemplateArgument (of a function
+	decl representing a template specialization) as an unsigned long long.
+
+	It is undefined to call this function on a CXCursor that does not represent a
+	FunctionDecl or whose I'th template argument is not an integral value.
+
+	For example, for the following declaration and specialization:
+	template <typename T, int kInt, bool kBool>
+	void foo() { ... }
+
+	template <>
+	void foo<float, 2147483649, true>();
+
+	If called with I = 1 or 2, 2147483649 or true will be returned, respectively.
+	For I == 0, this function's behavior is undefined.
+*/
+func (c Cursor) TemplateArgumentUnsignedValue(i uint16) uint64 {
+	return uint64(C.clang_Cursor_getTemplateArgumentUnsignedValue(c.c, C.uint(i)))
+}
+
 // Returns the Objective-C type encoding for the specified declaration.
 func (c Cursor) DeclObjCTypeEncoding() string {
 	o := cxstring{C.clang_getDeclObjCTypeEncoding(c.c)}
@@ -356,7 +460,7 @@ func (c Cursor) DeclObjCTypeEncoding() string {
 }
 
 /*
-	Retrieve the result type associated with a given cursor.
+	Retrieve the return type associated with a given cursor.
 
 	This only returns a valid type if the cursor refers to a function or method.
 */
@@ -387,6 +491,16 @@ func (c Cursor) IsVirtualBase() bool {
 */
 func (c Cursor) AccessSpecifier() AccessSpecifier {
 	return AccessSpecifier(C.clang_getCXXAccessSpecifier(c.c))
+}
+
+/*
+	Returns the storage class for a function or variable declaration.
+
+	If the passed in Cursor is not a function or variable declaration,
+	CX_SC_Invalid is returned else the storage class.
+*/
+func (c Cursor) StorageClass() _StorageClass {
+	return _StorageClass(C.clang_Cursor_getStorageClass(c.c))
 }
 
 /*
@@ -455,8 +569,8 @@ func (c Cursor) Spelling() string {
 /*
 	Retrieve a range for a piece that forms the cursors spelling name.
 	Most of the times there is only one range for the complete spelling but for
-	objc methods and objc message expressions, there are multiple pieces for each
-	selector identifier.
+	Objective-C methods and Objective-C message expressions, there are multiple
+	pieces for each selector identifier.
 
 	Parameter pieceIndex the index of the spelling name piece. If this is greater
 	than the actual number of pieces, it will return a NULL (invalid) range.
@@ -564,13 +678,13 @@ func (c Cursor) CanonicalCursor() Cursor {
 }
 
 /*
-	If the cursor points to a selector identifier in a objc method or
-	message expression, this returns the selector index.
+	If the cursor points to a selector identifier in an Objective-C
+	method or message expression, this returns the selector index.
 
 	After getting a cursor with #clang_getCursor, this can be called to
 	determine if the location points to a selector identifier.
 
-	Returns The selector index if the cursor is an objc method or message
+	Returns The selector index if the cursor is an Objective-C method or message
 	expression and the cursor is pointing to a selector identifier, or -1
 	otherwise.
 */
@@ -579,12 +693,12 @@ func (c Cursor) SelectorIndex() int16 {
 }
 
 /*
-	Given a cursor pointing to a C++ method call or an ObjC message,
-	returns non-zero if the method/message is "dynamic", meaning:
+	Given a cursor pointing to a C++ method call or an Objective-C
+	message, returns non-zero if the method/message is "dynamic", meaning:
 
 	For a C++ method: the call is virtual.
-	For an ObjC message: the receiver is an object instance, not 'super' or a
-	specific class.
+	For an Objective-C message: the receiver is an object instance, not 'super'
+	or a specific class.
 
 	If the method/message is "static" or the cursor does not point to a
 	method/message, it will return zero.
@@ -595,7 +709,7 @@ func (c Cursor) IsDynamicCall() bool {
 	return o != C.int(0)
 }
 
-// Given a cursor pointing to an ObjC message, returns the CXType of the receiver.
+// Given a cursor pointing to an Objective-C message, returns the CXType of the receiver.
 func (c Cursor) ReceiverType() Type {
 	return Type{C.clang_Cursor_getReceiverType(c.c)}
 }
@@ -611,12 +725,12 @@ func (c Cursor) PropertyAttributes(reserved uint16) uint16 {
 	return uint16(C.clang_Cursor_getObjCPropertyAttributes(c.c, C.uint(reserved)))
 }
 
-// Given a cursor that represents an ObjC method or parameter declaration, return the associated ObjC qualifiers for the return type or the parameter respectively. The bits are formed from CXObjCDeclQualifierKind.
+// Given a cursor that represents an Objective-C method or parameter declaration, return the associated Objective-C qualifiers for the return type or the parameter respectively. The bits are formed from CXObjCDeclQualifierKind.
 func (c Cursor) DeclQualifiers() uint16 {
 	return uint16(C.clang_Cursor_getObjCDeclQualifiers(c.c))
 }
 
-// Given a cursor that represents an ObjC method or property declaration, return non-zero if the declaration was affected by "@optional". Returns zero if the cursor is not such a declaration or it is "@required".
+// Given a cursor that represents an Objective-C method or property declaration, return non-zero if the declaration was affected by "@optional". Returns zero if the cursor is not such a declaration or it is "@required".
 func (c Cursor) IsObjCOptional() bool {
 	o := C.clang_Cursor_isObjCOptional(c.c)
 
@@ -651,9 +765,12 @@ func (c Cursor) BriefCommentText() string {
 	return o.String()
 }
 
-// Given a cursor that represents a documentable entity (e.g., declaration), return the associated parsed comment as a CXComment_FullComment AST node.
-func (c Cursor) ParsedComment() Comment {
-	return Comment{C.clang_Cursor_getParsedComment(c.c)}
+// Retrieve the CXString representing the mangled name of the cursor.
+func (c Cursor) Mangling() string {
+	o := cxstring{C.clang_Cursor_getMangling(c.c)}
+	defer o.Dispose()
+
+	return o.String()
 }
 
 // Given a CXCursor_ModuleImportDecl cursor, return the associated module.
@@ -678,6 +795,13 @@ func (c Cursor) CXXMethod_IsStatic() bool {
 // Determine if a C++ member function or member function template is explicitly declared 'virtual' or if it overrides a virtual method from one of the base classes.
 func (c Cursor) CXXMethod_IsVirtual() bool {
 	o := C.clang_CXXMethod_isVirtual(c.c)
+
+	return o != C.uint(0)
+}
+
+// Determine if a C++ member function or member function template is declared 'const'.
+func (c Cursor) CXXMethod_IsConst() bool {
+	o := C.clang_CXXMethod_isConst(c.c)
 
 	return o != C.uint(0)
 }

--- a/cursorkind_gen.go
+++ b/cursorkind_gen.go
@@ -225,7 +225,7 @@ const (
 		expression is not reported.
 	*/
 	Cursor_UnexposedExpr = C.CXCursor_UnexposedExpr
-	// An expression that refers to some value declaration, such as a function, varible, or enumerator.
+	// An expression that refers to some value declaration, such as a function, variable, or enumerator.
 	Cursor_DeclRefExpr = C.CXCursor_DeclRefExpr
 	// An expression that refers to a member of a struct, union, class, Objective-C class, etc.
 	Cursor_MemberRefExpr = C.CXCursor_MemberRefExpr
@@ -374,11 +374,11 @@ const (
 	Cursor_LambdaExpr     = C.CXCursor_LambdaExpr
 	// Objective-c Boolean Literal.
 	Cursor_ObjCBoolLiteralExpr = C.CXCursor_ObjCBoolLiteralExpr
-	// Represents the "self" expression in a ObjC method.
+	// Represents the "self" expression in an Objective-C method.
 	Cursor_ObjCSelfExpr = C.CXCursor_ObjCSelfExpr
-	// Represents the "self" expression in a ObjC method.
+	// Represents the "self" expression in an Objective-C method.
 	Cursor_LastExpr = C.CXCursor_LastExpr
-	// Represents the "self" expression in a ObjC method.
+	// Represents the "self" expression in an Objective-C method.
 	Cursor_FirstStmt = C.CXCursor_FirstStmt
 	/*
 		A statement whose specific kind is not exposed via this
@@ -466,7 +466,7 @@ const (
 	// A MS inline assembly statement extension.
 	Cursor_MSAsmStmt = C.CXCursor_MSAsmStmt
 	/*
-		The null satement ";": C99 6.8.3p3.
+		The null statement ";": C99 6.8.3p3.
 
 		This cursor kind is used to describe the null statement.
 	*/
@@ -475,7 +475,49 @@ const (
 	Cursor_DeclStmt = C.CXCursor_DeclStmt
 	// OpenMP parallel directive.
 	Cursor_OMPParallelDirective = C.CXCursor_OMPParallelDirective
-	// OpenMP parallel directive.
+	// OpenMP SIMD directive.
+	Cursor_OMPSimdDirective = C.CXCursor_OMPSimdDirective
+	// OpenMP for directive.
+	Cursor_OMPForDirective = C.CXCursor_OMPForDirective
+	// OpenMP sections directive.
+	Cursor_OMPSectionsDirective = C.CXCursor_OMPSectionsDirective
+	// OpenMP section directive.
+	Cursor_OMPSectionDirective = C.CXCursor_OMPSectionDirective
+	// OpenMP single directive.
+	Cursor_OMPSingleDirective = C.CXCursor_OMPSingleDirective
+	// OpenMP parallel for directive.
+	Cursor_OMPParallelForDirective = C.CXCursor_OMPParallelForDirective
+	// OpenMP parallel sections directive.
+	Cursor_OMPParallelSectionsDirective = C.CXCursor_OMPParallelSectionsDirective
+	// OpenMP task directive.
+	Cursor_OMPTaskDirective = C.CXCursor_OMPTaskDirective
+	// OpenMP master directive.
+	Cursor_OMPMasterDirective = C.CXCursor_OMPMasterDirective
+	// OpenMP critical directive.
+	Cursor_OMPCriticalDirective = C.CXCursor_OMPCriticalDirective
+	// OpenMP taskyield directive.
+	Cursor_OMPTaskyieldDirective = C.CXCursor_OMPTaskyieldDirective
+	// OpenMP barrier directive.
+	Cursor_OMPBarrierDirective = C.CXCursor_OMPBarrierDirective
+	// OpenMP taskwait directive.
+	Cursor_OMPTaskwaitDirective = C.CXCursor_OMPTaskwaitDirective
+	// OpenMP flush directive.
+	Cursor_OMPFlushDirective = C.CXCursor_OMPFlushDirective
+	// Windows Structured Exception Handling's leave statement.
+	Cursor_SEHLeaveStmt = C.CXCursor_SEHLeaveStmt
+	// OpenMP ordered directive.
+	Cursor_OMPOrderedDirective = C.CXCursor_OMPOrderedDirective
+	// OpenMP atomic directive.
+	Cursor_OMPAtomicDirective = C.CXCursor_OMPAtomicDirective
+	// OpenMP for SIMD directive.
+	Cursor_OMPForSimdDirective = C.CXCursor_OMPForSimdDirective
+	// OpenMP parallel for SIMD directive.
+	Cursor_OMPParallelForSimdDirective = C.CXCursor_OMPParallelForSimdDirective
+	// OpenMP target directive.
+	Cursor_OMPTargetDirective = C.CXCursor_OMPTargetDirective
+	// OpenMP teams directive.
+	Cursor_OMPTeamsDirective = C.CXCursor_OMPTeamsDirective
+	// OpenMP teams directive.
 	Cursor_LastStmt = C.CXCursor_LastStmt
 	/*
 		Cursor that represents the translation unit itself.
@@ -509,6 +551,22 @@ const (
 	Cursor_AsmLabelAttr = C.CXCursor_AsmLabelAttr
 	// An attribute whose specific kind is not exposed via this interface.
 	Cursor_PackedAttr = C.CXCursor_PackedAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_PureAttr = C.CXCursor_PureAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_ConstAttr = C.CXCursor_ConstAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_NoDuplicateAttr = C.CXCursor_NoDuplicateAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDAConstantAttr = C.CXCursor_CUDAConstantAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDADeviceAttr = C.CXCursor_CUDADeviceAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDAGlobalAttr = C.CXCursor_CUDAGlobalAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDAHostAttr = C.CXCursor_CUDAHostAttr
+	// An attribute whose specific kind is not exposed via this interface.
+	Cursor_CUDASharedAttr = C.CXCursor_CUDASharedAttr
 	// An attribute whose specific kind is not exposed via this interface.
 	Cursor_LastAttr = C.CXCursor_LastAttr
 	// An attribute whose specific kind is not exposed via this interface.

--- a/declqualifierkind_gen.go
+++ b/declqualifierkind_gen.go
@@ -5,7 +5,7 @@ package phoenix
 import "C"
 import "fmt"
 
-// 'Qualifiers' written next to the return and parameter types in ObjC method declarations.
+// 'Qualifiers' written next to the return and parameter types in Objective-C method declarations.
 type DeclQualifierKind uint32
 
 const (
@@ -34,10 +34,9 @@ func (dqk DeclQualifierKind) Spelling() string {
 		return "DeclQualifier=Byref"
 	case DeclQualifier_Oneway:
 		return "DeclQualifier=Oneway"
-
 	}
 
-	return fmt.Sprintf("DeclQualifierKind unkown %d", int(dqk))
+	return fmt.Sprintf("DeclQualifierKind unkown %d", dqk)
 }
 
 func (dqk DeclQualifierKind) String() string {

--- a/diagnosticdisplayoptions_gen.go
+++ b/diagnosticdisplayoptions_gen.go
@@ -84,10 +84,9 @@ func (ddo DiagnosticDisplayOptions) Spelling() string {
 		return "Diagnostic=DisplayCategoryId"
 	case Diagnostic_DisplayCategoryName:
 		return "Diagnostic=DisplayCategoryName"
-
 	}
 
-	return fmt.Sprintf("DiagnosticDisplayOptions unkown %d", int(ddo))
+	return fmt.Sprintf("DiagnosticDisplayOptions unkown %d", ddo)
 }
 
 func (ddo DiagnosticDisplayOptions) String() string {

--- a/diagnosticseverity_gen.go
+++ b/diagnosticseverity_gen.go
@@ -33,10 +33,9 @@ func (ds DiagnosticSeverity) Spelling() string {
 		return "Diagnostic=Error"
 	case Diagnostic_Fatal:
 		return "Diagnostic=Fatal"
-
 	}
 
-	return fmt.Sprintf("DiagnosticSeverity unkown %d", int(ds))
+	return fmt.Sprintf("DiagnosticSeverity unkown %d", ds)
 }
 
 func (ds DiagnosticSeverity) String() string {

--- a/file_gen.go
+++ b/file_gen.go
@@ -38,3 +38,10 @@ func (f File) UniqueID() (FileUniqueID, int16) {
 
 	return outID, o
 }
+
+// Returns non-zero if the file1 and file2 point to the same file, or they are both NULL.
+func (f File) IsEqual(file2 File) bool {
+	o := C.clang_File_isEqual(f.c, file2.c)
+
+	return o != C.int(0)
+}

--- a/globaloptflags_gen.go
+++ b/globaloptflags_gen.go
@@ -40,10 +40,9 @@ func (gof GlobalOptFlags) Spelling() string {
 		return "GlobalOpt=ThreadBackgroundPriorityForEditing"
 	case GlobalOpt_ThreadBackgroundPriorityForAll:
 		return "GlobalOpt=ThreadBackgroundPriorityForAll"
-
 	}
 
-	return fmt.Sprintf("GlobalOptFlags unkown %d", int(gof))
+	return fmt.Sprintf("GlobalOptFlags unkown %d", gof)
 }
 
 func (gof GlobalOptFlags) String() string {

--- a/idxattrkind_gen.go
+++ b/idxattrkind_gen.go
@@ -24,10 +24,9 @@ func (iak IdxAttrKind) Spelling() string {
 		return "IdxAttr=IBOutlet"
 	case IdxAttr_IBOutletCollection:
 		return "IdxAttr=IBOutletCollection"
-
 	}
 
-	return fmt.Sprintf("IdxAttrKind unkown %d", int(iak))
+	return fmt.Sprintf("IdxAttrKind unkown %d", iak)
 }
 
 func (iak IdxAttrKind) String() string {

--- a/idxdeclinfo_gen.go
+++ b/idxdeclinfo_gen.go
@@ -149,7 +149,7 @@ func (idi IdxDeclInfo) DeclAsContainer() *IdxContainerInfo {
 	return gop_o
 }
 
-// Whether the declaration exists in code or was created implicitly by the compiler, e.g. implicit objc methods for properties.
+// Whether the declaration exists in code or was created implicitly by the compiler, e.g. implicit Objective-C methods for properties.
 func (idi IdxDeclInfo) IsImplicit() bool {
 	o := idi.c.isImplicit
 

--- a/idxdeclinfoflags_gen.go
+++ b/idxdeclinfoflags_gen.go
@@ -15,10 +15,9 @@ func (idif IdxDeclInfoFlags) Spelling() string {
 	switch idif {
 	case IdxDeclFlag_Skipped:
 		return "IdxDeclFlag=Skipped"
-
 	}
 
-	return fmt.Sprintf("IdxDeclInfoFlags unkown %d", int(idif))
+	return fmt.Sprintf("IdxDeclInfoFlags unkown %d", idif)
 }
 
 func (idif IdxDeclInfoFlags) String() string {

--- a/idxentitycxxtemplatekind_gen.go
+++ b/idxentitycxxtemplatekind_gen.go
@@ -25,10 +25,9 @@ func (iecxxtk IdxEntityCXXTemplateKind) Spelling() string {
 		return "IdxEntity=TemplatePartialSpecialization"
 	case IdxEntity_TemplateSpecialization:
 		return "IdxEntity=TemplateSpecialization"
-
 	}
 
-	return fmt.Sprintf("IdxEntityCXXTemplateKind unkown %d", int(iecxxtk))
+	return fmt.Sprintf("IdxEntityCXXTemplateKind unkown %d", iecxxtk)
 }
 
 func (iecxxtk IdxEntityCXXTemplateKind) String() string {

--- a/idxentitykind_gen.go
+++ b/idxentitykind_gen.go
@@ -99,10 +99,9 @@ func (iek IdxEntityKind) Spelling() string {
 		return "IdxEntity=CXXTypeAlias"
 	case IdxEntity_CXXInterface:
 		return "IdxEntity=CXXInterface"
-
 	}
 
-	return fmt.Sprintf("IdxEntityKind unkown %d", int(iek))
+	return fmt.Sprintf("IdxEntityKind unkown %d", iek)
 }
 
 func (iek IdxEntityKind) String() string {

--- a/idxentitylanguage_gen.go
+++ b/idxentitylanguage_gen.go
@@ -24,10 +24,9 @@ func (iel IdxEntityLanguage) Spelling() string {
 		return "IdxEntityLang=ObjC"
 	case IdxEntityLang_CXX:
 		return "IdxEntityLang=CXX"
-
 	}
 
-	return fmt.Sprintf("IdxEntityLanguage unkown %d", int(iel))
+	return fmt.Sprintf("IdxEntityLanguage unkown %d", iel)
 }
 
 func (iel IdxEntityLanguage) String() string {

--- a/idxentityrefkind_gen.go
+++ b/idxentityrefkind_gen.go
@@ -11,7 +11,7 @@ type IdxEntityRefKind uint32
 const (
 	// The entity is referenced directly in user's code.
 	IdxEntityRef_Direct IdxEntityRefKind = C.CXIdxEntityRef_Direct
-	// An implicit reference, e.g. a reference of an ObjC method via the dot syntax.
+	// An implicit reference, e.g. a reference of an Objective-C method via the dot syntax.
 	IdxEntityRef_Implicit = C.CXIdxEntityRef_Implicit
 )
 
@@ -21,10 +21,9 @@ func (ierk IdxEntityRefKind) Spelling() string {
 		return "IdxEntityRef=Direct"
 	case IdxEntityRef_Implicit:
 		return "IdxEntityRef=Implicit"
-
 	}
 
-	return fmt.Sprintf("IdxEntityRefKind unkown %d", int(ierk))
+	return fmt.Sprintf("IdxEntityRefKind unkown %d", ierk)
 }
 
 func (ierk IdxEntityRefKind) String() string {

--- a/idxobjccontainerkind_gen.go
+++ b/idxobjccontainerkind_gen.go
@@ -21,10 +21,9 @@ func (iocck IdxObjCContainerKind) Spelling() string {
 		return "IdxObjCContainer=Interface"
 	case IdxObjCContainer_Implementation:
 		return "IdxObjCContainer=Implementation"
-
 	}
 
-	return fmt.Sprintf("IdxObjCContainerKind unkown %d", int(iocck))
+	return fmt.Sprintf("IdxObjCContainerKind unkown %d", iocck)
 }
 
 func (iocck IdxObjCContainerKind) String() string {

--- a/indexaction_gen.go
+++ b/indexaction_gen.go
@@ -36,11 +36,12 @@ func (ia IndexAction) Dispose() {
 	Parameter index_options A bitmask of options that affects how indexing is
 	performed. This should be a bitwise OR of the CXIndexOpt_XXX flags.
 
-	Parameter out_TU [out] pointer to store a CXTranslationUnit that can be reused
-	after indexing is finished. Set to NULL if you do not require it.
+	\param[out] out_TU pointer to store a CXTranslationUnit that can be
+	reused after indexing is finished. Set to NULL if you do not require it.
 
-	Returns If there is a failure from which the there is no recovery, returns
-	non-zero, otherwise returns 0.
+	Returns 0 on success or if there were errors from which the compiler could
+	recover. If there is a failure from which the there is no recovery, returns
+	a non-zero CXErrorCode.
 
 	The rest of the parameters are the same as #clang_parseTranslationUnit.
 */

--- a/indexoptflags_gen.go
+++ b/indexoptflags_gen.go
@@ -18,7 +18,7 @@ const (
 	IndexOpt_IndexImplicitTemplateInstantiations = C.CXIndexOpt_IndexImplicitTemplateInstantiations
 	// Suppress all compiler warnings when parsing for indexing.
 	IndexOpt_SuppressWarnings = C.CXIndexOpt_SuppressWarnings
-	// Skip a function/method body that was already parsed during an indexing session assosiated with a CXIndexAction object. Bodies in system headers are always skipped.
+	// Skip a function/method body that was already parsed during an indexing session associated with a CXIndexAction object. Bodies in system headers are always skipped.
 	IndexOpt_SkipParsedBodiesInSession = C.CXIndexOpt_SkipParsedBodiesInSession
 )
 
@@ -36,10 +36,9 @@ func (iof IndexOptFlags) Spelling() string {
 		return "IndexOpt=SuppressWarnings"
 	case IndexOpt_SkipParsedBodiesInSession:
 		return "IndexOpt=SkipParsedBodiesInSession"
-
 	}
 
-	return fmt.Sprintf("IndexOptFlags unkown %d", int(iof))
+	return fmt.Sprintf("IndexOptFlags unkown %d", iof)
 }
 
 func (iof IndexOptFlags) String() string {

--- a/languagekind_gen.go
+++ b/languagekind_gen.go
@@ -25,10 +25,9 @@ func (lk LanguageKind) Spelling() string {
 		return "Language=ObjC"
 	case Language_CPlusPlus:
 		return "Language=CPlusPlus"
-
 	}
 
-	return fmt.Sprintf("LanguageKind unkown %d", int(lk))
+	return fmt.Sprintf("LanguageKind unkown %d", lk)
 }
 
 func (lk LanguageKind) String() string {

--- a/linkagekind_gen.go
+++ b/linkagekind_gen.go
@@ -33,10 +33,9 @@ func (lk LinkageKind) Spelling() string {
 		return "Linkage=UniqueExternal"
 	case Linkage_External:
 		return "Linkage=External"
-
 	}
 
-	return fmt.Sprintf("LinkageKind unkown %d", int(lk))
+	return fmt.Sprintf("LinkageKind unkown %d", lk)
 }
 
 func (lk LinkageKind) String() string {

--- a/loaddiag_error_gen.go
+++ b/loaddiag_error_gen.go
@@ -29,10 +29,9 @@ func (lde LoadDiag_Error) Spelling() string {
 		return "LoadDiag=CannotLoad"
 	case LoadDiag_InvalidFile:
 		return "LoadDiag=InvalidFile"
-
 	}
 
-	return fmt.Sprintf("LoadDiag_Error unkown %d", int(lde))
+	return fmt.Sprintf("LoadDiag_Error unkown %d", lde)
 }
 
 func (lde LoadDiag_Error) String() string {

--- a/module_gen.go
+++ b/module_gen.go
@@ -51,3 +51,14 @@ func (m Module) FullName() string {
 
 	return o.String()
 }
+
+/*
+	Parameter Module a module object.
+
+	Returns non-zero if the module is a system one.
+*/
+func (m Module) IsSystem() bool {
+	o := C.clang_Module_isSystem(m.c)
+
+	return o != C.int(0)
+}

--- a/namerefflags_gen.go
+++ b/namerefflags_gen.go
@@ -18,7 +18,7 @@ const (
 		Non-contiguous names occur in Objective-C when a selector with two or more
 		parameters is used, or in C++ when using an operator:
 		\code
-		[object doSomething:here withValue:there]; // ObjC
+		[object doSomething:here withValue:there]; // Objective-C
 		return some_vector[1]; // C++
 		\endcode
 	*/
@@ -33,10 +33,9 @@ func (nrf NameRefFlags) Spelling() string {
 		return "NameRange=WantTemplateArgs"
 	case NameRange_WantSinglePiece:
 		return "NameRange=WantSinglePiece"
-
 	}
 
-	return fmt.Sprintf("NameRefFlags unkown %d", int(nrf))
+	return fmt.Sprintf("NameRefFlags unkown %d", nrf)
 }
 
 func (nrf NameRefFlags) String() string {

--- a/propertyattrkind_gen.go
+++ b/propertyattrkind_gen.go
@@ -52,10 +52,9 @@ func (pak PropertyAttrKind) Spelling() string {
 		return "PropertyAttr=strong"
 	case PropertyAttr_unsafe_unretained:
 		return "PropertyAttr=unsafe_unretained"
-
 	}
 
-	return fmt.Sprintf("PropertyAttrKind unkown %d", int(pak))
+	return fmt.Sprintf("PropertyAttrKind unkown %d", pak)
 }
 
 func (pak PropertyAttrKind) String() string {

--- a/refqualifierkind_gen.go
+++ b/refqualifierkind_gen.go
@@ -24,10 +24,9 @@ func (rqk RefQualifierKind) Spelling() string {
 		return "RefQualifier=LValue"
 	case RefQualifier_RValue:
 		return "RefQualifier=RValue"
-
 	}
 
-	return fmt.Sprintf("RefQualifierKind unkown %d", int(rqk))
+	return fmt.Sprintf("RefQualifierKind unkown %d", rqk)
 }
 
 func (rqk RefQualifierKind) String() string {

--- a/reparse_flags_gen.go
+++ b/reparse_flags_gen.go
@@ -23,10 +23,9 @@ func (rf Reparse_Flags) Spelling() string {
 	switch rf {
 	case Reparse_None:
 		return "Reparse=None"
-
 	}
 
-	return fmt.Sprintf("Reparse_Flags unkown %d", int(rf))
+	return fmt.Sprintf("Reparse_Flags unkown %d", rf)
 }
 
 func (rf Reparse_Flags) String() string {

--- a/result_gen.go
+++ b/result_gen.go
@@ -24,10 +24,9 @@ func (r Result) Spelling() string {
 		return "Result=Invalid"
 	case Result_VisitBreak:
 		return "Result=VisitBreak"
-
 	}
 
-	return fmt.Sprintf("Result unkown %d", int(r))
+	return fmt.Sprintf("Result unkown %d", r)
 }
 
 func (r Result) String() string {

--- a/saveerror_gen.go
+++ b/saveerror_gen.go
@@ -41,10 +41,9 @@ func (se SaveError) Spelling() string {
 		return "SaveError=TranslationErrors"
 	case SaveError_InvalidTU:
 		return "SaveError=InvalidTU"
-
 	}
 
-	return fmt.Sprintf("SaveError unkown %d", int(se))
+	return fmt.Sprintf("SaveError unkown %d", se)
 }
 
 func (se SaveError) String() string {

--- a/savetranslationunit_flags_gen.go
+++ b/savetranslationunit_flags_gen.go
@@ -23,10 +23,9 @@ func (stuf SaveTranslationUnit_Flags) Spelling() string {
 	switch stuf {
 	case SaveTranslationUnit_None:
 		return "SaveTranslationUnit=None"
-
 	}
 
-	return fmt.Sprintf("SaveTranslationUnit_Flags unkown %d", int(stuf))
+	return fmt.Sprintf("SaveTranslationUnit_Flags unkown %d", stuf)
 }
 
 func (stuf SaveTranslationUnit_Flags) String() string {

--- a/string_gen.go
+++ b/string_gen.go
@@ -8,7 +8,7 @@ import "C"
 	A character string.
 
 	The CXString type is used to return strings from the interface when
-	the ownership of that string might different from one call to the next.
+	the ownership of that string might differ from one call to the next.
 	Use clang_getCString() to retrieve the string data and, once finished
 	with the string data, call clang_disposeString() to free the string.
 */

--- a/tokenkind_gen.go
+++ b/tokenkind_gen.go
@@ -33,10 +33,9 @@ func (tk TokenKind) Spelling() string {
 		return "Token=Literal"
 	case Token_Comment:
 		return "Token=Comment"
-
 	}
 
-	return fmt.Sprintf("TokenKind unkown %d", int(tk))
+	return fmt.Sprintf("TokenKind unkown %d", tk)
 }
 
 func (tk TokenKind) String() string {

--- a/translationunit_flags_gen.go
+++ b/translationunit_flags_gen.go
@@ -111,10 +111,9 @@ func (tuf TranslationUnit_Flags) Spelling() string {
 		return "TranslationUnit=SkipFunctionBodies"
 	case TranslationUnit_IncludeBriefCommentsInCodeCompletion:
 		return "TranslationUnit=IncludeBriefCommentsInCodeCompletion"
-
 	}
 
-	return fmt.Sprintf("TranslationUnit_Flags unkown %d", int(tuf))
+	return fmt.Sprintf("TranslationUnit_Flags unkown %d", tuf)
 }
 
 func (tuf TranslationUnit_Flags) String() string {

--- a/turesourceusagekind_gen.go
+++ b/turesourceusagekind_gen.go
@@ -36,7 +36,7 @@ func (turuk TUResourceUsageKind) Name() string {
 
 func (turuk TUResourceUsageKind) Spelling() string {
 	switch turuk {
-	case TUResourceUsage_AST /*TUResourceUsage_MEMORY_IN_BYTES_BEGIN*/ /*TUResourceUsage_First*/ :
+	case TUResourceUsage_AST:
 		return "TUResourceUsage=AST, MEMORY_IN_BYTES_BEGIN, First"
 	case TUResourceUsage_Identifiers:
 		return "TUResourceUsage=Identifiers"
@@ -62,12 +62,11 @@ func (turuk TUResourceUsageKind) Spelling() string {
 		return "TUResourceUsage=PreprocessingRecord"
 	case TUResourceUsage_SourceManager_DataStructures:
 		return "TUResourceUsage=SourceManager_DataStructures"
-	case TUResourceUsage_Preprocessor_HeaderSearch /*TUResourceUsage_MEMORY_IN_BYTES_END*/ /*TUResourceUsage_Last*/ :
+	case TUResourceUsage_Preprocessor_HeaderSearch:
 		return "TUResourceUsage=Preprocessor_HeaderSearch, MEMORY_IN_BYTES_END, Last"
-
 	}
 
-	return fmt.Sprintf("TUResourceUsageKind unkown %d", int(turuk))
+	return fmt.Sprintf("TUResourceUsageKind unkown %d", turuk)
 }
 
 func (turuk TUResourceUsageKind) String() string {

--- a/type_gen.go
+++ b/type_gen.go
@@ -88,7 +88,7 @@ func (t Type) FunctionTypeCallingConv() CallingConv {
 }
 
 /*
-	Retrieve the result type associated with a function type.
+	Retrieve the return type associated with a function type.
 
 	If a non-function type is passed in, an invalid type is returned.
 */
@@ -97,7 +97,7 @@ func (t Type) ResultType() Type {
 }
 
 /*
-	Retrieve the number of non-variadic arguments associated with a
+	Retrieve the number of non-variadic parameters associated with a
 	function type.
 
 	If a non-function type is passed in, -1 is returned.
@@ -107,7 +107,7 @@ func (t Type) NumArgTypes() int16 {
 }
 
 /*
-	Retrieve the type of an argument of a function type.
+	Retrieve the type of a parameter of a function type.
 
 	If a non-function type is passed in or the function does not have enough
 	parameters, an invalid type is returned.
@@ -224,6 +224,28 @@ func (t Type) OffsetOf(s string) int64 {
 	defer C.free(unsafe.Pointer(c_s))
 
 	return int64(C.clang_Type_getOffsetOf(t.c, c_s))
+}
+
+/*
+	Returns the number of template arguments for given class template
+	specialization, or -1 if type T is not a class template specialization.
+
+	Variadic argument packs count as only one argument, and can not be inspected
+	further.
+*/
+func (t Type) NumTemplateArguments() int16 {
+	return int16(C.clang_Type_getNumTemplateArguments(t.c))
+}
+
+/*
+	Returns the type template argument of a template class specialization
+	at given index.
+
+	This function only returns template type arguments and does not handle
+	template template arguments or variadic packs.
+*/
+func (t Type) TemplateArgumentAsType(i uint16) Type {
+	return Type{C.clang_Type_getTemplateArgumentAsType(t.c, C.uint(i))}
 }
 
 /*

--- a/typekind_gen.go
+++ b/typekind_gen.go
@@ -8,7 +8,7 @@ import "C"
 type TypeKind uint32
 
 const (
-	// Reprents an invalid type (e.g., where no type is available).
+	// Represents an invalid type (e.g., where no type is available).
 	Type_Invalid TypeKind = C.CXType_Invalid
 	// A type whose specific kind is not exposed via this interface.
 	Type_Unexposed = C.CXType_Unexposed

--- a/typelayouterror_gen.go
+++ b/typelayouterror_gen.go
@@ -40,10 +40,9 @@ func (tle TypeLayoutError) Spelling() string {
 		return "TypeLayoutError=NotConstantSize"
 	case TypeLayoutError_InvalidFieldName:
 		return "TypeLayoutError=InvalidFieldName"
-
 	}
 
-	return fmt.Sprintf("TypeLayoutError unkown %d", int(tle))
+	return fmt.Sprintf("TypeLayoutError unkown %d", tle)
 }
 
 func (tle TypeLayoutError) String() string {

--- a/visitorresult_gen.go
+++ b/visitorresult_gen.go
@@ -18,10 +18,9 @@ func (vr VisitorResult) Spelling() string {
 		return "Visit=Break"
 	case Visit_Continue:
 		return "Visit=Continue"
-
 	}
 
-	return fmt.Sprintf("VisitorResult unkown %d", int(vr))
+	return fmt.Sprintf("VisitorResult unkown %d", vr)
 }
 
 func (vr VisitorResult) String() string {


### PR DESCRIPTION
Spelling, String and Error where up to this point always created with templates now switched to generating the ast