### PR TITLE
Handle definitions over different files

### DIFF
--- a/cmd/go-clang-generate/generate/clang/cmd.go
+++ b/cmd/go-clang-generate/generate/clang/cmd.go
@@ -94,20 +94,8 @@ func Cmd(args []string, api *generate.API) error {
 		}
 	}
 
-	headers, err := ioutil.ReadDir(clangCDirectory)
-	if err != nil {
-		return cmdFatal("Cannot list clang-c directory", err)
-	}
-	for _, h := range headers {
-		name := h.Name()
-
-		if h.IsDir() || !strings.HasSuffix(name, ".h") {
-			continue
-		}
-
-		if err := api.HandleHeaderFile(clangCDirectory + name); err != nil {
-			return cmdFatal(fmt.Sprintf("Cannot handle header file %q", name), err)
-		}
+	if err := api.HandleDirectory(clangCDirectory); err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/go-clang-generate/generate/enum.go
+++ b/cmd/go-clang-generate/generate/enum.go
@@ -10,7 +10,7 @@ import (
 
 // Enum represents a generation enum
 type Enum struct {
-	HeaderFile string
+	IncludeFiles includeFiles
 
 	Name           string
 	CName          string
@@ -37,6 +37,8 @@ func handleEnumCursor(cursor clang.Cursor, cname string, cnameIsTypeDef bool) *E
 		CName:          cname,
 		CNameIsTypeDef: cnameIsTypeDef,
 		Comment:        CleanDoxygenComment(cursor.RawCommentText()),
+
+		IncludeFiles: newIncludeFiles(),
 
 		Items: []EnumItem{},
 	}

--- a/cmd/go-clang-generate/generate/function.go
+++ b/cmd/go-clang-generate/generate/function.go
@@ -12,6 +12,8 @@ import (
 
 // Function represents a generation function
 type Function struct {
+	IncludeFiles includeFiles
+
 	Name    string
 	CName   string
 	Comment string
@@ -40,6 +42,8 @@ func newFunction(name, cname, comment, member string, typ Type) *Function {
 		Name:    functionName,
 		CName:   cname,
 		Comment: comment,
+
+		IncludeFiles: newIncludeFiles(),
 
 		Parameters: []FunctionParameter{ // TODO this might not be needed if the receiver code is refactored https://github.com/zimmski/go-clang-phoenix/issues/52
 			FunctionParameter{
@@ -74,6 +78,8 @@ func handleFunctionCursor(cursor clang.Cursor) *Function {
 		Name:    fname,
 		CName:   fname,
 		Comment: CleanDoxygenComment(cursor.RawCommentText()),
+
+		IncludeFiles: newIncludeFiles(),
 
 		Parameters: []FunctionParameter{},
 	}

--- a/cmd/go-clang-generate/generate/includefiles.go
+++ b/cmd/go-clang-generate/generate/includefiles.go
@@ -1,0 +1,17 @@
+package generate
+
+type includeFiles map[string]struct{}
+
+func newIncludeFiles() includeFiles {
+	return includeFiles(map[string]struct{}{})
+}
+
+func (inf includeFiles) addIncludeFile(includeFile string) {
+	inf[includeFile] = struct{}{}
+}
+
+func (inf includeFiles) unifyIncludeFiles(m includeFiles) {
+	for i := range m {
+		inf[i] = struct{}{}
+	}
+}

--- a/cmd/go-clang-generate/generate/struct.go
+++ b/cmd/go-clang-generate/generate/struct.go
@@ -10,7 +10,7 @@ import (
 type Struct struct {
 	api *API
 
-	HeaderFile string
+	IncludeFiles includeFiles
 
 	Name           string
 	CName          string
@@ -36,6 +36,8 @@ func handleStructCursor(cursor clang.Cursor, cname string, cnameIsTypeDef bool) 
 		CName:          cname,
 		CNameIsTypeDef: cnameIsTypeDef,
 		Comment:        CleanDoxygenComment(cursor.RawCommentText()),
+
+		IncludeFiles: newIncludeFiles(),
 	}
 
 	s.Name = TrimLanguagePrefix(s.CName)

--- a/cmd/go-clang-generate/main.go
+++ b/cmd/go-clang-generate/main.go
@@ -144,7 +144,7 @@ func prepareFunction(f *generate.Function) {
 }
 
 func filterFunction(f *generate.Function) bool {
-	// Some functions are not compiled in (TODO only 3.4?) the library see https://lists.launchpad.net/desktop-packages/msg75835.html for a never resolved bug report https://github.com/zimmski/go-clang-phoenix/issues/59
+	// Some functions are not compiled in the library see https://lists.launchpad.net/desktop-packages/msg75835.html for a never resolved bug report
 	if f.CName == "clang_CompileCommand_getMappedSourceContent" || f.CName == "clang_CompileCommand_getMappedSourcePath" || f.CName == "clang_CompileCommand_getNumMappedSources" {
 		fmt.Printf("Ignore function %q because it is not compiled within libClang\n", f.CName)
 

--- a/cmd/go-clang-generate/main.go
+++ b/cmd/go-clang-generate/main.go
@@ -163,6 +163,13 @@ func filterFunction(f *generate.Function) bool {
 		return false
 	}
 
+	// TODO if this function is from CXString.h we ignore it https://github.com/zimmski/go-clang-phoenix/issues/25
+	for i := range f.IncludeFiles {
+		if strings.HasSuffix(i, "CXString.h") {
+			return false
+		}
+	}
+
 	return true
 }
 


### PR DESCRIPTION
The problem is that we have to include every needed header of a function in a .go file because CGo has a per file scope.